### PR TITLE
templateconf: add summary and notes

### DIFF
--- a/conf/templates/bisdn-linux/conf-notes.txt
+++ b/conf/templates/bisdn-linux/conf-notes.txt
@@ -1,0 +1,13 @@
+### Shell environment set up for builds. ###
+
+You can now run 'bitbake <target>'
+
+Common targets are:
+    full
+    minimal
+    packagegroup-bisdn-linux-extra
+
+Other commonly useful commands are:
+ - 'devtool' and 'recipetool' handle common recipe tasks
+ - 'bitbake-layers' handles common layer tasks
+ - 'oe-pkgdata-util' handles common target package tasks

--- a/conf/templates/bisdn-linux/conf-summary.txt
+++ b/conf/templates/bisdn-linux/conf-summary.txt
@@ -1,0 +1,1 @@
+This is the default build configuration for the BISDN Linux distribution.


### PR DESCRIPTION
Add a summary of the template config and notes based on the default poky notes [1] which will be shown to the developer when initializing the build directory.

[1] https://git.yoctoproject.org/poky/tree/meta-poky/conf/templates/default/conf-notes.txt