### PR TITLE
switch_tcpdump: handle SIGTERM signal indication

### DIFF
--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -29,6 +29,7 @@
 
 import argparse
 import builtins
+import ctypes
 import functools
 import os
 import signal
@@ -189,11 +190,7 @@ def rule_insert(portNumber):
         text=True,
         capture_output=True)
 
-    rc = int.from_bytes(
-        completed_process.returncode.to_bytes(1, "little", signed=False),
-        "little",
-        signed=True,
-    )
+    rc = ctypes.c_int8(completed_process.returncode)
 
     if rc not in [0, -25]:
         print(completed_process.stdout)
@@ -217,11 +214,7 @@ def rule_delete(portNumber):
         text=True,
         capture_output=True)
 
-    rc = int.from_bytes(
-        completed_process.returncode.to_bytes(1, "little", signed=False),
-        "little",
-        signed=True,
-    )
+    rc = ctypes.c_int8(completed_process.returncode)
 
     if rc not in [0, -30]:
         print(completed_process.stdout)

--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -144,6 +144,10 @@ def main():
         args.filters,
         extra_args)
 
+    if tcpdumpReturnCode == -15:
+      # SIGTERM was received, which is not an error.
+      tcpdumpReturnCode = 0
+
     # Remove the rule from the ACL table in case it was not removed by the
     # signal handler. Not having the rule anymore (-30) is not an error.
     if rule_delete(portNumber) not in [0, -30]:
@@ -271,7 +275,7 @@ def run_tcpdump(portName, filePath, timeoutSeconds,
 
     if filePath:
         print(f"Final file size: {os.path.getsize(filePath)/1e6} MB")
-    return tcpdumpProcess.returncode
+    return ctypes.c_int8(tcpdumpProcess.returncode)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
If switch_tcpdump terminates the tcpdump process (for instance, because
 the timeout has been reached), then the returncode of the subprocess may
be -15, the negative value of SIGTERM (it is racy, but it does happen).
    
That is not an error we want to pass on as the exit status for
switch_tcpdump, so in that case, set the exit status to 0.
