### PR TITLE
switch_tcpdump: use c_byte value, not object

### DIFF
--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -194,7 +194,7 @@ def rule_insert(portNumber):
         text=True,
         capture_output=True)
 
-    rc = ctypes.c_int8(completed_process.returncode)
+    rc = ctypes.c_int8(completed_process.returncode).value
 
     if rc not in [0, -25]:
         print(completed_process.stdout)
@@ -218,7 +218,7 @@ def rule_delete(portNumber):
         text=True,
         capture_output=True)
 
-    rc = ctypes.c_int8(completed_process.returncode)
+    rc = ctypes.c_int8(completed_process.returncode).value
 
     if rc not in [0, -30]:
         print(completed_process.stdout)
@@ -275,7 +275,7 @@ def run_tcpdump(portName, filePath, timeoutSeconds,
 
     if filePath:
         print(f"Final file size: {os.path.getsize(filePath)/1e6} MB")
-    return ctypes.c_int8(tcpdumpProcess.returncode)
+    return ctypes.c_int8(tcpdumpProcess.returncode).value
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The previous commits which introduced the ctypes library neglected the fact that c_int8 returns a c_byte object. For comparisons to integers, we need to get the object's value, not the object itself.

Fixes: 32e7e69 ("switch_tcpdump: handle SIGTERM signal indication")
Fixes: e627acc ("switch_tcpdump: use ctypes to convert to int8")