### PR TITLE
frr: fix CVE-2024-44070

### DIFF
--- a/recipes-protocols/frr/frr/0001-CVE-2024-44070.patch
+++ b/recipes-protocols/frr/frr/0001-CVE-2024-44070.patch
@@ -1,0 +1,55 @@
+From ab70eee423cce4a06103f52cb4a2e3bd2740afa2 Mon Sep 17 00:00:00 2001
+From: Donatas Abraitis <donatas@opensourcerouting.org>
+Date: Wed, 31 Jul 2024 08:35:14 +0300
+Subject: [PATCH] bgpd: Check the actual remaining stream length before taking
+ TLV value
+
+```
+    0 0xb50b9f898028 in __sanitizer_print_stack_trace (/home/ubuntu/frr-public/frr_public_private-libfuzzer/bgpd/.libs/bgpd+0x368028) (BuildId: 3292703ed7958b20076550c967f879db8dc27ca7)
+    1 0xb50b9f7ed8e4 in fuzzer::PrintStackTrace() (/home/ubuntu/frr-public/frr_public_private-libfuzzer/bgpd/.libs/bgpd+0x2bd8e4) (BuildId: 3292703ed7958b20076550c967f879db8dc27ca7)
+    2 0xb50b9f7d4d9c in fuzzer::Fuzzer::CrashCallback() (/home/ubuntu/frr-public/frr_public_private-libfuzzer/bgpd/.libs/bgpd+0x2a4d9c) (BuildId: 3292703ed7958b20076550c967f879db8dc27ca7)
+    3 0xe0d12d7469cc  (linux-vdso.so.1+0x9cc) (BuildId: 1a77697e9d723fe22246cfd7641b140c427b7e11)
+    4 0xe0d12c88f1fc in __pthread_kill_implementation nptl/pthread_kill.c:43:17
+    5 0xe0d12c84a678 in gsignal signal/../sysdeps/posix/raise.c:26:13
+    6 0xe0d12c83712c in abort stdlib/abort.c:79:7
+    7 0xe0d12d214724 in _zlog_assert_failed /home/ubuntu/frr-public/frr_public_private-libfuzzer/lib/zlog.c:789:2
+    8 0xe0d12d1285e4 in stream_get /home/ubuntu/frr-public/frr_public_private-libfuzzer/lib/stream.c:324:3
+    9 0xb50b9f8e47c4 in bgp_attr_encap /home/ubuntu/frr-public/frr_public_private-libfuzzer/bgpd/bgp_attr.c:2758:3
+    10 0xb50b9f8dcd38 in bgp_attr_parse /home/ubuntu/frr-public/frr_public_private-libfuzzer/bgpd/bgp_attr.c:3783:10
+    11 0xb50b9faf74b4 in bgp_update_receive /home/ubuntu/frr-public/frr_public_private-libfuzzer/bgpd/bgp_packet.c:2383:20
+    12 0xb50b9faf1dcc in bgp_process_packet /home/ubuntu/frr-public/frr_public_private-libfuzzer/bgpd/bgp_packet.c:4075:11
+    13 0xb50b9f8c90d0 in LLVMFuzzerTestOneInput /home/ubuntu/frr-public/frr_public_private-libfuzzer/bgpd/bgp_main.c:582:3
+```
+
+Reported-by: Iggy Frankovic <iggyfran@amazon.com>
+Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>
+(cherry picked from commit 0998b38e4d61179441f90dd7e7fd6a3a8b7bd8c5)
+CVE: CVE-2024-44070
+Upstream-Status: Backport [https://github.com/FRRouting/frr/commit/5748034271261aa622b967283ccefdc89272f8fe]
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ bgpd/bgp_attr.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/bgpd/bgp_attr.c b/bgpd/bgp_attr.c
+index 0023a0176826..889902efcb0a 100644
+--- a/bgpd/bgp_attr.c
++++ b/bgpd/bgp_attr.c
+@@ -2687,6 +2687,14 @@ static int bgp_attr_encap(struct bgp_attr_parser_args *args)
+ 						  args->total);
+ 		}
+ 
++		if (STREAM_READABLE(BGP_INPUT(peer)) < sublength) {
++			zlog_err("Tunnel Encap attribute sub-tlv length %d exceeds remaining stream length %zu",
++				 sublength, STREAM_READABLE(BGP_INPUT(peer)));
++			return bgp_attr_malformed(args,
++						  BGP_NOTIFY_UPDATE_OPT_ATTR_ERR,
++						  args->total);
++		}
++
+ 		/* alloc and copy sub-tlv */
+ 		/* TBD make sure these are freed when attributes are released */
+ 		tlv = XCALLOC(MTYPE_ENCAP_TLV,
+-- 
+2.46.0
+

--- a/recipes-protocols/frr/frr_9.0.3.bb
+++ b/recipes-protocols/frr/frr_9.0.3.bb
@@ -10,6 +10,7 @@ LIC_FILES_CHKSUM = "file://doc/licenses/GPL-2.0;md5=b234ee4d69f5fce4486a80fdaf4a
                     file://doc/licenses/LGPL-2.1;md5=4fbd65380cdd255951079008b364516c"
 
 SRC_URI = "git://github.com/FRRouting/frr.git;protocol=https;branch=stable/9.0 \
+           file://0001-CVE-2024-44070.patch \
            file://frr.pam \
            "
 


### PR DESCRIPTION
Fix CVE-2024-44070 by cherry-picking the upstream fix.

ref: https://nvd.nist.gov/vuln/detail/CVE-2024-44070