### PR TITLE
onie-nos-installer: fix sstate skip for onie-bundle

### DIFF
--- a/recipes-core/images/onie-nos-installer.inc
+++ b/recipes-core/images/onie-nos-installer.inc
@@ -61,7 +61,8 @@ do_onie_bundle () {
     ln -sf "./onie-bisdn-${IMAGE_NAME}.bin" "./onie-bisdn-${IMAGE_LINK_NAME}.bin"
 }
 
-SSTATE_SKIP_CREATION:task-onie-bundle = '0'
+SSTATETASKS += "do_onie_bundle"
+SSTATE_SKIP_CREATION:task-onie-bundle = '1'
 
 addtask do_onie_bundle after do_image_complete before do_build
 


### PR DESCRIPTION
Presumably the intention of this value was to skip the sstate creation for the onie-bundle task, but setting it 0 allows it.

Fix this by setting SSTATE_SKIP_CREATION to 1, and also state the SSTATE_TASKS so it actually becomes considered (or so).