### PR TITLE
baseboxd-tools: also collect nexthop info in debug bundle

### DIFF
--- a/recipes-extended/baseboxd-tools/baseboxd-tools/bundle-debug-info
+++ b/recipes-extended/baseboxd-tools/baseboxd-tools/bundle-debug-info
@@ -149,6 +149,7 @@ function get_network_state() {
   log_cmd_output ip a
   log_cmd_output ip route list table all
   log_cmd_output ip neigh
+  log_cmd_output ip nexthop
   log_cmd_output bridge fdb
   if grep -q bridge.ko "/lib/modules/$(uname -r)/modules.builtin" ||
       grep "^bridge " /proc/modules; then


### PR DESCRIPTION
FRR will create named nexthops for all routes, so we should collect all active nexthops as well.