### PR TITLE
baseboxd: drop service file location fixup

### DIFF
--- a/recipes-extended/baseboxd/baseboxd_2.2.5.bb
+++ b/recipes-extended/baseboxd/baseboxd_2.2.5.bb
@@ -15,10 +15,6 @@ do_install:append() {
    # install service file and config
    install -m 0644 ${S}/pkg/systemd/sysconfig.template ${D}${sysconfdir}/default/baseboxd
 
-   # HACK: baseboxd.service is installed into the wrong dir. we should configure this proper.
-   rm -rf ${D}/usr/lib
-   install -m 0644 ${B}/baseboxd.service ${D}${systemd_unitdir}/system
-
    # update service file
    sed -i -e 's,/etc/sysconfig/baseboxd,/etc/default/baseboxd,g' \
           ${D}${systemd_unitdir}/system/baseboxd.service


### PR DESCRIPTION
Since baseboxd 2.2.1 we install the service file at the expected location, so we do not need to manually copy it anymore.

No changes in generated package:

    $ sha256sum before/* after/*
    10ef217e5bff25e0d3ea8affee2c2e9a6f61b68ff1c6d5b405694541773e090f  before/baseboxd_2.2.5-r0_corei7-64.ipk
    10ef217e5bff25e0d3ea8affee2c2e9a6f61b68ff1c6d5b405694541773e090f  after/baseboxd_2.2.5-r0_corei7-64.ipk