### PR TITLE
frr: enable capabilities to fix racy unprivileged executions

### DIFF
--- a/recipes-protocols/frr/frr_9.0.4.bbappend
+++ b/recipes-protocols/frr/frr_9.0.4.bbappend
@@ -36,6 +36,7 @@ PACKAGECONFIG ??= " \
     ${@bb.utils.filter('FRR_EXTRA_CONF', 'cumulus', d)} \
     ${@bb.utils.filter('FRR_EXTRA_CONF', 'datacenter', d)} \
     ${@bb.utils.filter('DISTRO_FEATURES', 'snmp', d)} \
+    capabilities \
     ospfclient \
     "
 


### PR DESCRIPTION
Without libcap privilege is attained per process instead of per thread. Apart from being slow due to the need for synchronization [1], it is even broken as it does not guard unprivileged executions from being run in privileged context [2].

Fix this by always enabling libcap.

[1] https://github.com/FRRouting/frr/commit/7bfe765ae06fcc0a5570fdd793237e5fa828f7e7
[2] https://github.com/FRRouting/frr/issues/16747