### PR TITLE
mstpd: correctly reported version as 0.1.0+bisdn6

### DIFF
--- a/recipes-support/mstpd/mstpd_0.1.0.bb
+++ b/recipes-support/mstpd/mstpd_0.1.0.bb
@@ -8,7 +8,7 @@ SRC_URI = "\
   file://bridge-stp.conf"
 
 PV:append = "+bisdn6"
-SRCREV = "809b744636307dce72807ec5e73e1a10f4ccd008"
+SRCREV = "e3424dff8667bd901a9a349ab18718159b65b263"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
The 0.1.0+bisdn6 branch missed the version bump, so the binary still reported as 0.1.0+bisdn5. Fix this by moving to the correct commit.

Fixes: a9d0100212fe ("mstpd: fix path cost calculation for link speeds > 65G")