### PR TITLE
v4.x: update branch references as appropriate

### DIFF
--- a/conf/distro/bisdn-linux.conf
+++ b/conf/distro/bisdn-linux.conf
@@ -15,7 +15,7 @@ DISTROOVERRIDES = "poky:bisdn-linux"
 EXTRAOPKGCONFIG   = "b-isdn-feed-config-opkg"
 
 FEEDNAMEPREFIX ??= "${DISTRO_VERSION}"
-FEEDURIPREFIX  ??= "nightly_builds/${MACHINE}/master/packages_latest-build"
+FEEDURIPREFIX  ??= "nightly_builds/${MACHINE}/v4.x/packages_latest-build"
 FEEDDOMAIN     ??= "http://repo.bisdn.de"
 
 DISTRO_FEATURES_DEFAULT ?= "acl argp ext2 ipv4 ipv6 largefile pci pcmcia systemd usbgadget usbhost virtualization xattr"

--- a/recipes-extended/baseboxd/baseboxd.inc
+++ b/recipes-extended/baseboxd/baseboxd.inc
@@ -20,7 +20,7 @@ DEPENDS = "\
     systemd \
 "
 
-SRC_URI = "gitsm://github.com/bisdn/basebox.git;protocol=https;branch=master"
+SRC_URI = "gitsm://github.com/bisdn/basebox.git;protocol=https;branch=1.x"
 S = "${WORKDIR}/git"
 
 inherit pkgconfig systemd

--- a/recipes-support/rofl-common/rofl-common.inc
+++ b/recipes-support/rofl-common/rofl-common.inc
@@ -12,7 +12,7 @@ DEPENDS = " \
 "
 
 SRC_URI = " \
-	git://github.com/bisdn/rofl-common.git;protocol=https;branch=master \
+	git://github.com/bisdn/rofl-common.git;protocol=https;branch=main \
 	file://001-fix-configure-glog.patch \
         "
 

--- a/recipes-support/rofl-ofdpa/rofl-ofdpa.inc
+++ b/recipes-support/rofl-ofdpa/rofl-ofdpa.inc
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=815ca599c9df247a0c7f619bab123dad"
 
 DEPENDS = "rofl-common"
 
-SRC_URI = "git://github.com/bisdn/rofl-ofdpa.git;protocol=https;branch=master"
+SRC_URI = "git://github.com/bisdn/rofl-ofdpa.git;protocol=https;branch=main"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Update branch references as appropriate:

* baseboxd: use 1.x
* rofl-*: use main for now
* distro/FEEDURIPREFIX: use v4.x (the bisdn-linux branch for v4.x)