### PR TITLE
v4.x: backport libnl fixes

### DIFF
--- a/recipes-support/libnl/libnl/0005-bridge-vlan-add-per-vlan-stp-state-object-and-cache.patch
+++ b/recipes-support/libnl/libnl/0005-bridge-vlan-add-per-vlan-stp-state-object-and-cache.patch
@@ -1,4 +1,4 @@
-From 02f023bb1b37f66746707697048d47aabe4f534e Mon Sep 17 00:00:00 2001
+From 72a75773b65fe0c151c236ddc60793efc3b88613 Mon Sep 17 00:00:00 2001
 From: Rubens Figueiredo <rubens.figueiredo@bisdn.de>
 Date: Tue, 10 Aug 2021 11:23:39 +0200
 Subject: [PATCH 5/6] bridge-vlan: add per vlan stp state object and cache
@@ -12,13 +12,13 @@ Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
  include/netlink-private/types.h     |  11 +
  include/netlink/cli/bridge_vlan.h   |  23 ++
  include/netlink/route/bridge_vlan.h |  42 ++++
- lib/route/bridge_vlan.c             | 361 ++++++++++++++++++++++++++++
+ lib/route/bridge_vlan.c             | 362 ++++++++++++++++++++++++++++
  libnl-cli-3.sym                     |   7 +
  libnl-route-3.sym                   |  13 +
  src/lib/bridge_vlan.c               |  42 ++++
  src/nl-bridge.c                     |  38 +++
  src/nl-monitor.c                    |   1 +
- 11 files changed, 546 insertions(+)
+ 11 files changed, 547 insertions(+)
  create mode 100644 include/netlink/cli/bridge_vlan.h
  create mode 100644 include/netlink/route/bridge_vlan.h
  create mode 100644 lib/route/bridge_vlan.c
@@ -189,10 +189,10 @@ index 000000000000..62f2994c7d85
 +#endif
 diff --git a/lib/route/bridge_vlan.c b/lib/route/bridge_vlan.c
 new file mode 100644
-index 000000000000..36c2b490732f
+index 000000000000..929c67af67b2
 --- /dev/null
 +++ b/lib/route/bridge_vlan.c
-@@ -0,0 +1,361 @@
+@@ -0,0 +1,362 @@
 +/* SPDX-License-Identifier: LGPL-2.1-only */
 +/*
 + * lib/route/bridge_vlan.c		Bridge VLAN database
@@ -283,9 +283,10 @@ index 000000000000..36c2b490732f
 +		return err;
 +
 +	struct nlattr *pos;
-+	int rem = nlh->nlmsg_len;
++	int rem = nlh->nlmsg_len - NLMSG_LENGTH(sizeof(*bmsg));
 +
-+	for (pos = nlmsg_data(nlh); nla_ok(pos, rem); pos = nla_next(pos, &rem)) {
++	for (pos = nlmsg_data(nlh) + NLMSG_ALIGN(sizeof(*bmsg));
++	     nla_ok(pos, rem); pos = nla_next(pos, &rem)) {
 +		struct bridge_vlan_info *bvlan_info = NULL;
 +		uint16_t range = 0;
 +		uint8_t state = 0;
@@ -698,5 +699,5 @@ index 86294fbe317d..17225aa2c0a5 100644
  };
  
 -- 
-2.37.0
+2.42.0
 

--- a/recipes-support/libnl/libnl/0007-lib-attr-handle-default-routes.patch
+++ b/recipes-support/libnl/libnl/0007-lib-attr-handle-default-routes.patch
@@ -1,0 +1,191 @@
+From 0c0aee829c1d2d468d89eda75d38e7490e4de575 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Fri, 24 Jun 2022 14:07:21 +0200
+Subject: [PATCH 1/4] addr: create an all-zero addresses when parsing "any" or
+ "default"
+
+When calling nl_addr_parse() is called with "any" or "default", the
+constructed address will have zero-length address data. This has the
+side effect that a comparison with e.g. an address contructed from
+"0.0.0.0/0" will fail, since their address has different lengths, even
+if they should be equal.
+
+Fix this by allocating an appropriate zeroed address for "any" and
+"default", but do not for "none", since "none" implies no address.
+
+Upstream-Status: Accepted [https://github.com/thom311/libnl/pull/320]
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ lib/addr.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/lib/addr.c b/lib/addr.c
+index fae129343ec7..ab4bf2210cf1 100644
+--- a/lib/addr.c
++++ b/lib/addr.c
+@@ -325,14 +325,17 @@ int nl_addr_parse(const char *addrstr, int hint, struct nl_addr **result)
+ 				 * no hint given the user wants to have a IPv4
+ 				 * address given back. */
+ 				family = AF_INET;
++				len = 4;
+ 				goto prefix;
+ 
+ 			case AF_INET6:
+ 				family = AF_INET6;
++				len = 16;
+ 				goto prefix;
+ 
+ 			case AF_LLC:
+ 				family = AF_LLC;
++				len = 6;
+ 				goto prefix;
+ 
+ 			default:
+@@ -449,6 +452,8 @@ prefix:
+ 
+ 	if (copy)
+ 		nl_addr_set_binary_addr(addr, buf, len);
++	else
++		addr->a_len = len;
+ 
+ 	if (prefix) {
+ 		char *p;
+@@ -460,7 +465,7 @@ prefix:
+ 		}
+ 		nl_addr_set_prefixlen(addr, pl);
+ 	} else {
+-		if (!plen)
++		if (copy && !plen)
+ 			plen = len * 8;
+ 		nl_addr_set_prefixlen(addr, plen);
+ 	}
+-- 
+2.42.0
+
+
+From 25d42a4f3c7daa5e14f174a31f14c4e1f2289e46 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Fri, 24 Jun 2022 14:27:40 +0200
+Subject: [PATCH 2/4] addr: allow constructing all-zero addresses
+
+Allow easy contruction of all-zero addresses by not passing a buf to
+copy. Since the object is allocated with calloc, the address data will
+default to all-zero, and only the length needs to be set.
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ lib/addr.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/addr.c b/lib/addr.c
+index ab4bf2210cf1..d0b5f3379a25 100644
+--- a/lib/addr.c
++++ b/lib/addr.c
+@@ -226,7 +226,7 @@ struct nl_addr *nl_addr_build(int family, const void *buf, size_t size)
+ 		addr->a_prefixlen = size*8;
+ 	}
+ 
+-	if (size)
++	if (size && buf)
+ 		memcpy(addr->a_addr, buf, size);
+ 
+ 	return addr;
+-- 
+2.42.0
+
+
+From 8d40d9eb3360ec1f4c2ca8df8c0f87ca8334889e Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Fri, 24 Jun 2022 14:34:30 +0200
+Subject: [PATCH 3/4] route: construct all-zero addresses for default route
+ destination
+
+A default route is equivalent to a 0.0.0.0/0 or ::/0 route, so we should
+construct the dst as such with a all-zero address.
+
+Since this breaks the assumption that a dst with a 0 address length is a
+default route, switch to checking the prefix length being 0, and make
+sure that there is an address part that is all-zero.
+
+This ensures we will print the actual dst in case the address is not
+zero, or does not exist.
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ lib/route/route_obj.c | 21 ++++++++++++++++++---
+ 1 file changed, 18 insertions(+), 3 deletions(-)
+
+diff --git a/lib/route/route_obj.c b/lib/route/route_obj.c
+index 9441b77a76e5..cd61fd595df0 100644
+--- a/lib/route/route_obj.c
++++ b/lib/route/route_obj.c
+@@ -145,7 +145,8 @@ static void route_dump_line(struct nl_object *a, struct nl_dump_params *p)
+ 		nl_dump(p, "cache ");
+ 
+ 	if (!(r->ce_mask & ROUTE_ATTR_DST) ||
+-	    nl_addr_get_len(r->rt_dst) == 0)
++	    (nl_addr_get_prefixlen(r->rt_dst) == 0 &&
++	     nl_addr_get_len(r->rt_dst) > 0 && nl_addr_iszero(r->rt_dst)))
+ 		nl_dump(p, "default ");
+ 	else
+ 		nl_dump(p, "%s ", nl_addr2str(r->rt_dst, buf, sizeof(buf)));
+@@ -1156,9 +1157,23 @@ int rtnl_route_parse(struct nlmsghdr *nlh, struct rtnl_route **result)
+ 		if (!(dst = nl_addr_alloc_attr(tb[RTA_DST], family)))
+ 			return -NLE_NOMEM;
+ 	} else {
+-		if (!(dst = nl_addr_alloc(0)))
++		int len;
++
++		switch (family) {
++			case AF_INET:
++				len = 4;
++				break;
++
++			case AF_INET6:
++				len = 16;
++				break;
++			default:
++				len = 0;
++				break;
++		}
++
++		if (!(dst = nl_addr_build(family, NULL, len)))
+ 			return -NLE_NOMEM;
+-		nl_addr_set_family(dst, rtm->rtm_family);
+ 	}
+ 
+ 	nl_addr_set_prefixlen(dst, rtm->rtm_dst_len);
+-- 
+2.42.0
+
+
+From 0461a425b31722eded615c75a4dd681cf8bddd62 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Fri, 24 Jun 2022 14:47:16 +0200
+Subject: [PATCH 4/4] attr: reject zero length addresses
+
+A zero length address is not a valid address in netlink, so we should
+not try to send them to the kernel.
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ lib/attr.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/lib/attr.c b/lib/attr.c
+index 6838dba392f0..1363afbbbb52 100644
+--- a/lib/attr.c
++++ b/lib/attr.c
+@@ -541,6 +541,9 @@ int nla_put_data(struct nl_msg *msg, int attrtype, const struct nl_data *data)
+  */
+ int nla_put_addr(struct nl_msg *msg, int attrtype, struct nl_addr *addr)
+ {
++	if (nl_addr_get_len(addr) == 0)
++		return -NLE_INVAL;
++
+ 	return nla_put(msg, attrtype, nl_addr_get_len(addr),
+ 		       nl_addr_get_binary_addr(addr));
+ }
+-- 
+2.42.0
+

--- a/recipes-support/libnl/libnl/0008-link-ignore-incomplete-bridge-updates.patch
+++ b/recipes-support/libnl/libnl/0008-link-ignore-incomplete-bridge-updates.patch
@@ -1,0 +1,72 @@
+From 01269e0cde032b503261b8c71cfcce3c119af903 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Wed, 24 Apr 2024 14:13:22 +0200
+Subject: [PATCH] link: ignore incomplete bridge updates
+
+For currently unknown reasons, the kernel sends a minimal RTM_NEWLINK
+message for a bridge shortly after attaching a port:
+
+-- Debug: Received Message:
+--------------------------   BEGIN NETLINK MESSAGE ---------------------------
+  [NETLINK HEADER] 16 octets
+    .nlmsg_len = 96
+    .type = 16 <route/link::new>
+    .flags = 0 <>
+    .seq = 0
+    .port = 0
+  [PAYLOAD] 16 octets
+    07 00 01 00 40 00 00 00 03 10 00 00 00 00 00 00 ....@...........
+  [ATTR 03] 9 octets
+    73 77 62 72 69 64 67 65 00                      swbridge.
+  [PADDING] 3 octets
+    00 00 00                                        ...
+  [ATTR 10] 4 octets
+    40 00 00 00                                     @...
+  [ATTR 04] 4 octets
+    dc 05 00 00                                     ....
+  [ATTR 16] 1 octets
+    02                                              .
+  [PADDING] 3 octets
+    00 00 00                                        ...
+  [ATTR 01] 6 octets
+    da 56 2f bc 9f 33                               .V/..3
+  [PADDING] 2 octets
+    00 00                                           ..
+  [ATTR 26] 8 octets
+    08 00 02 00 00 00 01 00                         ........
+---------------------------  END NETLINK MESSAGE   ---------------------------
+
+This minimal message does not contain any IFLA_INFO_KIND, but has its
+family set to AF_BRIDGE. This causes the full bridge object in the link
+cache to be replaced with this minimal one, breaking any attempts to get
+information about the bridge interface from the cache.
+
+Work around for now by ignoring these updates.
+
+Upstream-Status: Reported [https://github.com/thom311/libnl/issues/377]
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ lib/route/link.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/lib/route/link.c b/lib/route/link.c
+index 2410391f3de3..89fe3d197691 100644
+--- a/lib/route/link.c
++++ b/lib/route/link.c
+@@ -746,6 +746,13 @@ static int link_msg_parser(struct nl_cache_ops *ops, struct sockaddr_nl *who,
+ 		}
+ 	}
+ 
++	/* ignore incomplete link objects with family set but no kind set */
++	if (   link->ce_msgtype == RTM_NEWLINK
++	    && link->l_family == AF_BRIDGE
++	    && !(link->ce_mask & LINK_ATTR_LINKINFO)
++	    && link->l_index == link->l_master)
++		return 0;
++
+ 	if (   tb[IFLA_PROTINFO]
+ 	    && link->l_af_ops
+ 	    && link->l_af_ops->ao_parse_protinfo) {
+-- 
+2.46.1
+

--- a/recipes-support/libnl/libnl_3.7.0.bb
+++ b/recipes-support/libnl/libnl_3.7.0.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "http://www.infradead.org/~tgr/libnl/"
 SECTION = "libs/network"
 
 PE = "1"
-PR = "r2"
+PR = "r3"
 
 LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
@@ -21,6 +21,7 @@ SRC_URI = " \
     file://0005-bridge-vlan-add-per-vlan-stp-state-object-and-cache.patch \
     file://0006-route-route_obj-treat-each-IPv6-link-local-route-as-.patch \
     file://0007-lib-attr-handle-default-routes.patch \
+    file://0008-link-ignore-incomplete-bridge-updates.patch \
 "
 
 # commit hash of release tag libnl3_7_0

--- a/recipes-support/libnl/libnl_3.7.0.bb
+++ b/recipes-support/libnl/libnl_3.7.0.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "http://www.infradead.org/~tgr/libnl/"
 SECTION = "libs/network"
 
 PE = "1"
-PR = "r1"
+PR = "r2"
 
 LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
@@ -20,6 +20,7 @@ SRC_URI = " \
     file://0004-sync-linux-headers-with-5.11.patch \
     file://0005-bridge-vlan-add-per-vlan-stp-state-object-and-cache.patch \
     file://0006-route-route_obj-treat-each-IPv6-link-local-route-as-.patch \
+    file://0007-lib-attr-handle-default-routes.patch \
 "
 
 # commit hash of release tag libnl3_7_0

--- a/recipes-support/libnl/libnl_3.7.0.bb
+++ b/recipes-support/libnl/libnl_3.7.0.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "http://www.infradead.org/~tgr/libnl/"
 SECTION = "libs/network"
 
 PE = "1"
-PR = "r0"
+PR = "r1"
 
 LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"


### PR DESCRIPTION
Backport the following libnl fixes:

* libnl: bridge_vlan: properly account for the bridge_vlan header (#161)
* libnl: backport default route handling from 3.8.0 (#165)
* libnl: ignore incomplete bridge updates (#190)