### PR TITLE
distro: enable static group ids and user ids

### DIFF
--- a/conf/distro/bisdn-linux.conf
+++ b/conf/distro/bisdn-linux.conf
@@ -30,3 +30,7 @@ VOLATILE_LOG_DIR = "no"
 
 # we do not have seccomp in DISTRO_FEATURES, so do not enable it for docker
 PACKAGECONFIG:pn-docker-ce ?= "docker-init"
+
+# use static uid/gid allocation to avoid renumeration on upgrade
+USERADDEXTENSION = "useradd-staticids"
+USERADD_ERROR_DYNAMIC = "error"

--- a/files/group
+++ b/files/group
@@ -1,0 +1,67 @@
+# based on BISDN Linux 5.2.1's /etc/group
+
+# base-passwd
+root:x:0:
+daemon:x:1:
+bin:x:2:
+sys:x:3:
+adm:x:4:
+tty:x:5:
+disk:x:6:
+lp:x:7:
+mail:x:8:
+news:x:9:
+uucp:x:10:
+man:x:12:
+proxy:x:13:
+kmem:x:15:
+input:x:19:
+dialout:x:20:
+fax:x:21:
+voice:x:22:
+cdrom:x:24:
+floppy:x:25:
+tape:x:26:
+sudo:x:27:
+audio:x:29:
+dip:x:30:
+www-data:x:33:
+backup:x:34:
+operator:x:37:
+list:x:38:
+irc:x:39:
+src:x:40:
+gnats:x:41:
+shadow:x:42:
+utmp:x:43:
+video:x:44:
+sasl:x:45:
+plugdev:x:46:
+kvm:x:47:
+staff:x:50:
+games:x:60:
+shutdown:x:70:
+users:x:100:
+nogroup:x:65534:
+
+# systemd
+wheel:x:984:
+systemd-journal-gateway:x:985:
+systemd-timesync:x:986:
+systemd-resolve:x:987:
+systemd-network:x:988:
+systemd-coredump:x:989:
+systemd-journal:x:990:
+sgx:x:994:
+render:x:995:
+systemd-bus-proxy:x:996:
+
+# basebox-user
+basebox:x:1000:
+
+# packages
+docker:x:991:
+frrvty:x:992:
+frr:x:993:
+sshd:x:998:
+messagebus:x:999:

--- a/files/passwd
+++ b/files/passwd
@@ -1,0 +1,38 @@
+# based on BISDN Linux 5.2.1's /etc/passwd
+
+# base-passwd
+root:x:0::::
+daemon:x:1::::
+bin:x:2::::
+sys:x:3::::
+sync:x:4::::
+games:x:5::::
+man:x:6::::
+lp:x:7::::
+mail:x:8::::
+news:x:9::::
+uucp:x:10::::
+proxy:x:13::::
+www-data:x:33::::
+backup:x:34::::
+list:x:38::::
+irc:x:39::::
+gnats:x:41::::
+nobody:x:65534::::
+
+# systemd
+systemd-journal-gateway:x:990::::
+systemd-timesync:x:991::::
+systemd-resolve:x:992::::
+systemd-network:x:993::::
+systemd-coredump:x:994::::
+systemd-bus-proxy:x:996::::
+
+# basebox-user
+basebox:x:1000::::
+
+# packages
+frr:x:995::::
+radvd:x:997::::
+sshd:x:998::::
+messagebus:x:999::::

--- a/recipes-core/systemd/systemd.inc
+++ b/recipes-core/systemd/systemd.inc
@@ -30,3 +30,28 @@ do_install:append() {
 }
 
 USERADD_PARAM:${PN} += "--system --home /dev/null systemd-journal-gateway"
+
+# values taken from BISDN Linux 5.2.1's /etc/passwd and /etc/group
+EXTRA_OEMESON:append = " \
+ -Dadm-gid=4 \
+ -Dtty-gid=5 \
+ -Ddisk-gid=6 \
+ -Dlp-gid=7 \
+ -Dkmem-gid=15 \
+ -Dinput-gid=19 \
+ -Ddialout-gid=20 \
+ -Dcdrom-gid=24 \
+ -Dtape-gid=26 \
+ -Daudio-gid=29 \
+ -Dutmp-gid=43 \
+ -Dvideo-gid=44 \
+ -Dkvm-gid=47 \
+ -Dusers-gid=100 \
+ -Dwheel-gid=984 \
+ -Dsystemd-journal-gid=990 \
+ -Dsgx-gid=994 \
+ -Drender-gid=995 \
+ -Dsystemd-timesync-uid=991 \
+ -Dsystemd-resolve-uid=992 \
+ -Dsystemd-network-uid=993 \
+"


### PR DESCRIPTION
By default user ids and group ids are dynamically allocation on addition to the system. This isn't an issue for a fresh installation, but on upgrade, the run-preinsts service on first boot will add any missing users and groups that weren't present in the taken over passwd/group files.

These then might get assigned different ids than the one of the image, which then can cause a mismatch for ownership of supplied files and directories in the image.

Especially systemd's wheel group will take the lowest id in the 900s, which can change when adding new services with new users and groups to the image.

To fix that, enable the "useradd-staticids" USERADDEXTENSION, where Yocto will use ids from files/{passwd,groups} when adding users via USERADD:*, and make it fatal if a user or group does not have an id in those files.

Unfortunately systemd has its own way of adding missing default users and groups, so we need to supply the expected uids/gids as meson arguments, so add these appropriately.

The content of files/{passwd,group} is taken from BISDN Linux 5.2.1, with everything dropped exept for names and ids, annotated and ordered in ascending order within in subgroups.