### PR TITLE
packagegroup-bisdn-linux-extra: add valgrind

### DIFF
--- a/recipes-extended/packagegroups/packagegroup-bisdn-linux-extra.bb
+++ b/recipes-extended/packagegroups/packagegroup-bisdn-linux-extra.bb
@@ -21,6 +21,7 @@ RDEPENDS:${PN} = "\
 RDEPENDS:${PN} += "\
     gdb \
     strace \
+    valgrind \
     zstd \
 "
 


### PR DESCRIPTION
Valgrind is a useful utility to debug memory issues (leaks, use-after-free, etc), so add it to the debugging extra set.