### PR TITLE
full: include python3-docker

### DIFF
--- a/recipes-core/images/full.bb
+++ b/recipes-core/images/full.bb
@@ -36,6 +36,7 @@ BISDN_SWITCH_IMAGE_EXTRA_INSTALL += "\
     ofdpa-tools \
     procps \
     python3 \
+    python3-docker \
     python3-ofdpa \
     python3-pip \
     python3-ryu \


### PR DESCRIPTION
We make use of the python3 docker module in our testing, so we should just include it instead of installing later.