### PR TITLE
files/groups: update wheel/sgx GIDs

### DIFF
--- a/files/group
+++ b/files/group
@@ -38,21 +38,21 @@ video:x:44:
 sasl:x:45:
 plugdev:x:46:
 kvm:x:47:
+sgx:x:48:
 staff:x:50:
 games:x:60:
 shutdown:x:70:
+wheel:x:80:
 users:x:100:
 nogroup:x:65534:
 
 # systemd
-wheel:x:984:
 systemd-journal-gateway:x:985:
 systemd-timesync:x:986:
 systemd-resolve:x:987:
 systemd-network:x:988:
 systemd-coredump:x:989:
 systemd-journal:x:990:
-sgx:x:994:
 render:x:995:
 systemd-bus-proxy:x:996:
 
@@ -65,3 +65,7 @@ frrvty:x:992:
 frr:x:993:
 sshd:x:998:
 messagebus:x:999:
+
+# reserved (were used in earlier releases)
+reserved984:x:984:
+reserved994:x:994:


### PR DESCRIPTION
The wheel and sgx groups are now provided by base-passwd with static GIDs since [1] and [2], so update our files/group to match this.

Since when upgrading from older releases these groups may still have the old GIDs, keep them as reserved entries in the file to prevent reusing them in the future.

[1] https://git.openembedded.org/openembedded-core/commit/?h=kirkstone&id=4cafad1a0ef5506151656fd644dcdf3193245173
[2] https://git.openembedded.org/openembedded-core/commit/?h=kirkstone&id=a20b02fdfe64c005f7587a1d9077bdc282f7b6b1