### PR TITLE
full: replace docker-ce with docker-moby

### DIFF
--- a/conf/distro/bisdn-linux.conf
+++ b/conf/distro/bisdn-linux.conf
@@ -29,7 +29,7 @@ DISTRO_FEATURES:remove = "alsa opengl wayland vulkan"
 VOLATILE_LOG_DIR = "no"
 
 # we do not have seccomp in DISTRO_FEATURES, so do not enable it for docker
-PACKAGECONFIG:pn-docker-ce ?= "docker-init"
+PACKAGECONFIG:pn-docker-moby ?= "docker-init"
 
 # use static uid/gid allocation to avoid renumeration on upgrade
 USERADDEXTENSION = "useradd-staticids"

--- a/recipes-core/images/full.bb
+++ b/recipes-core/images/full.bb
@@ -10,7 +10,7 @@ BISDN_SWITCH_IMAGE_EXTRA_INSTALL += "\
     baseboxd-tools \
     bridge-utils  \
     curl \
-    docker-ce \
+    docker-moby \
     ethtool \
     file \
     frr \


### PR DESCRIPTION
Code wise docker-ce is identical to docker-moby, the only difference is the package name and version:

    SRCREV_docker = "791d8ab87747169b4cbfcdf2fd57c81952bae6d5"
    DOCKER_VERSION = "20.10.25-ce"

vs

    SRCREV_moby = "791d8ab87747169b4cbfcdf2fd57c81952bae6d5"
    DOCKER_VERSION = "20.10.25"

newer Yocto versions therefore dropped the docker-ce package, so we should also not use it anymore. So let's switch docker to the "new" package.