### PR TITLE
distro: set PREFERRED_PROVIDER for docker to docker-moby

### DIFF
--- a/conf/distro/bisdn-linux.conf
+++ b/conf/distro/bisdn-linux.conf
@@ -28,6 +28,7 @@ DISTRO_FEATURES:remove = "alsa opengl wayland vulkan"
 # disable symlinking of /var/volatile to /var/log to enable persistent logs
 VOLATILE_LOG_DIR = "no"
 
+PREFERRED_PROVIDER_virtual/docker = "docker-moby"
 # we do not have seccomp in DISTRO_FEATURES, so do not enable it for docker
 PACKAGECONFIG:pn-docker-moby ?= "docker-init"
 


### PR DESCRIPTION
We can't just replace docker-ce with docker-moby, we also need to override the preferred provider to make the change effective.

Fixes the following build error:

```
ERROR: Nothing RPROVIDES 'docker-moby' (but meta-bisdn-linux/recipes-core/images/full.bb RDEPENDS on or otherwise requires it)
docker-moby was skipped: PREFERRED_PROVIDER_virtual/docker set to docker-ce, not docker-moby
ERROR: Required build target 'full' has no buildable providers.
```

Fixes: 12eda9946056 ("full: replace docker-ce with docker-moby")