### PR TITLE
mstpd: use ${base_sbindir} instead of hardcoding /sbin

### DIFF
--- a/recipes-support/mstpd/mstpd_0.1.0.bb
+++ b/recipes-support/mstpd/mstpd_0.1.0.bb
@@ -14,7 +14,7 @@ S = "${WORKDIR}/git"
 
 inherit autotools systemd
 
-EXTRA_OECONF = "--sbindir=/sbin"
+EXTRA_OECONF = "--sbindir=${base_sbindir}"
 
 # Uncomment the following lines to enable debug output in the binary.
 # Output is sent as level 4.


### PR DESCRIPTION
Instead of hardcoding /sbin as the sbindir, use ${base_sbindir} for it. This variable will properly follow usrmerge if enabled.

Installing to /usr/sbin in this case is harmless, as /sbin will be symlink to /usr/sbin, so any /sbin/* calls will continue to work.