### PR TITLE
installer: add a naive systemd service state backup and restore

### DIFF
--- a/scripts/installer/lib/backup.sh
+++ b/scripts/installer/lib/backup.sh
@@ -134,12 +134,21 @@ create_backup()
 		[ -f "$file" ] || break
 		parse_file $file "+" $1 $2
 	done
-	parse_file "$1/$SYSTEM_BACKUP_FILE" "+" $1 $2
-	parse_file "$1/$USER_BACKUP_FILE" "+" $1 $2
+	if [ -f "$1/$SYSTEM_BACKUP_FILE" ]; then
+		parse_file "$1/$SYSTEM_BACKUP_FILE" "+" $1 $2
+	fi
+
+	if [ -f "$1/$USER_BACKUP_FILE" ]; then
+		parse_file "$1/$USER_BACKUP_FILE" "+" $1 $2
+	fi
 
 	# step 2 - remove files to drop
-	parse_file "$1/$SYSTEM_BACKUP_FILE" "-" $1 $2
-	parse_file "$1/$USER_BACKUP_FILE" "-" $1 $2
+	if [ -f "$1/$SYSTEM_BACKUP_FILE" ]; then
+		parse_file "$1/$SYSTEM_BACKUP_FILE" "-" $1 $2
+	fi
+	if [ -f "$1/$SYSTEM_BACKUP_FILE" ]; then
+		parse_file "$1/$USER_BACKUP_FILE" "-" $1 $2
+	fi
 
 	apply_fixups $1 $2
 
@@ -182,6 +191,7 @@ restore_backup()
 
     # now copy the files
     for file in $1/*; do
+	    [ -e "$file" ] || continue
 	    cp -a $file $2
     done
 }


### PR DESCRIPTION
Add support for backing up and restoring explicitly disabled and enabled
services by checking their symlinks and restoring or removing them when
applying the backup.

It does naive enabled/disabled services heuristic:

- if the .preset does not say enabled, and there is a symlink in
  multi-user.target.wants, recreate the symink on restore
- if the .preset says enabled, and there was no symlink in
  multi-user.target.wants, remove the symlink on restore

Additionally, it only checks certain services:
- Skip any oneshot services (these are expected to be disabled with
  enabled preset after first boot)
- Skip any services not targeting multi-user

It does support parameterized services though, as supported by frr (via
frr@something).

This allows e.g. docker to continue to be enabled after an update to a
newer version. It should now also keep the choice of baseboxd vs ryu on
upgrade (untested though).