### PR TITLE
libnl: import latest updates from upstream

### DIFF
--- a/recipes-support/libnl/libnl/0001-cache-cache_include-fix-double-put-for-cloned-object.patch
+++ b/recipes-support/libnl/libnl/0001-cache-cache_include-fix-double-put-for-cloned-object.patch
@@ -1,7 +1,7 @@
-From 53b1a14162d640272607150ff53d5d42904cdbc4 Mon Sep 17 00:00:00 2001
+From df44fb5768c1825721da915a295bc881d6701e04 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 17 Dec 2024 14:54:38 +0100
-Subject: [PATCH 7/7] cache: cache_include(): fix double put for cloned objects
+Subject: [PATCH 1/9] cache: cache_include(): fix double put for cloned objects
 
 When switching to auto obj, a nl_object_put() was left inplace in
 cache_include(). This leads to a double reference drop of the cloned

--- a/recipes-support/libnl/libnl/0002-route-add-missing-rtnl_nh_get_oif-symbol.patch
+++ b/recipes-support/libnl/libnl/0002-route-add-missing-rtnl_nh_get_oif-symbol.patch
@@ -1,0 +1,36 @@
+From cf4953aeea458400e7f75745b16ac42c95b76d87 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Tue, 4 Feb 2025 14:44:44 +0100
+Subject: [PATCH 2/9] route: add missing rtnl_nh_get_oif symbol
+
+When nh support was added in 780d06ae8bee ("route: add nh type"),
+rtnl_nh_get_oif() was missed adding to libnl-route-3.sym.
+
+Add the missing symbol so it can be actually used.
+
+Fixes: 780d06ae8bee ("route: add nh type")
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+
+https://github.com/thom311/libnl/pull/419
+Upstream-Status: Backport [https://github.com/thom311/libnl/commit/470c0a62b8b26d7dcf553f859a7abcd62d6b0890]
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ libnl-route-3.sym | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/libnl-route-3.sym b/libnl-route-3.sym
+index 75883323c8df..17e3fde21e3b 100644
+--- a/libnl-route-3.sym
++++ b/libnl-route-3.sym
+@@ -1364,3 +1364,8 @@ global:
+ 	rtnl_neigh_str2extflag;
+ 	rtnl_neigh_unset_ext_flags;
+ } libnl_3_10;
++
++libnl_3_12 {
++global:
++	rtnl_nh_get_oif;
++} libnl_3_11;
+-- 
+2.47.1
+

--- a/recipes-support/libnl/libnl/0003-cache-add-nl_cache_resync_v2.patch
+++ b/recipes-support/libnl/libnl/0003-cache-add-nl_cache_resync_v2.patch
@@ -1,0 +1,106 @@
+From f4996c0832479100b8eb4b78ce0e5ebfbc4dc3c1 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Mon, 3 Feb 2025 14:57:49 +0100
+Subject: [PATCH 3/9] cache: add nl_cache_resync_v2()
+
+When the include callback v2 support was added in 66d032ad443a
+("cache_mngr: add include callback v2"), resync_cb() was updated to
+handle both old and v2 callbacks, but no actual nl_cache_resync_v2() was
+added to make use of it.
+
+Fix this by adding an appropriate implementation.
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+
+https://github.com/thom311/libnl/pull/420
+Upstream-Status: Backport [https://github.com/thom311/libnl/commit/b7e1b4aa7f745d2e64518916ddf19c8801b29084]
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ include/netlink/cache.h |  4 ++++
+ lib/cache.c             | 21 +++++++++++++++++++--
+ libnl-3.sym             |  5 +++++
+ 3 files changed, 28 insertions(+), 2 deletions(-)
+
+diff --git a/include/netlink/cache.h b/include/netlink/cache.h
+index 955f9799b532..85b7b25b3279 100644
+--- a/include/netlink/cache.h
++++ b/include/netlink/cache.h
+@@ -80,6 +80,10 @@ extern int			nl_cache_resync(struct nl_sock *,
+ 						struct nl_cache *,
+ 						change_func_t,
+ 						void *);
++extern int			nl_cache_resync_v2(struct nl_sock *,
++						   struct nl_cache *,
++						   change_func_v2_t,
++						   void *);
+ extern int			nl_cache_include(struct nl_cache *,
+ 						 struct nl_object *,
+ 						 change_func_t,
+diff --git a/lib/cache.c b/lib/cache.c
+index 9df24ea87c75..e2cc6dfcd7f7 100644
+--- a/lib/cache.c
++++ b/lib/cache.c
+@@ -902,14 +902,16 @@ static int resync_cb(struct nl_object *c, struct nl_parser_param *p)
+ 					ca->ca_change_data);
+ }
+ 
+-int nl_cache_resync(struct nl_sock *sk, struct nl_cache *cache,
+-		    change_func_t change_cb, void *data)
++static int cache_resync(struct nl_sock *sk, struct nl_cache *cache,
++			change_func_t change_cb, change_func_v2_t change_cb_v2,
++			void *data)
+ {
+ 	struct nl_object *obj, *next;
+ 	struct nl_af_group *grp;
+ 	struct nl_cache_assoc ca = {
+ 		.ca_cache = cache,
+ 		.ca_change = change_cb,
++		.ca_change_v2 = change_cb_v2,
+ 		.ca_change_data = data,
+ 	};
+ 	struct nl_parser_param p = {
+@@ -954,6 +956,9 @@ restart:
+ 			nl_cache_remove(obj);
+ 			if (change_cb)
+ 				change_cb(cache, obj, NL_ACT_DEL, data);
++			else if (change_cb_v2)
++				change_cb_v2(cache, obj, NULL, 0, NL_ACT_DEL,
++					     data);
+ 			nl_object_put(obj);
+ 		}
+ 	}
+@@ -965,6 +970,18 @@ errout:
+ 	return err;
+ }
+ 
++int nl_cache_resync(struct nl_sock *sk, struct nl_cache *cache,
++		    change_func_t change_cb, void *data)
++{
++	return cache_resync(sk, cache, change_cb, NULL, data);
++}
++
++int nl_cache_resync_v2(struct nl_sock *sk, struct nl_cache *cache,
++		    change_func_v2_t change_cb_v2, void *data)
++{
++	return cache_resync(sk, cache, NULL, change_cb_v2, data);
++}
++
+ /** @} */
+ 
+ /**
+diff --git a/libnl-3.sym b/libnl-3.sym
+index b5a33bba1013..8df31c952bdc 100644
+--- a/libnl-3.sym
++++ b/libnl-3.sym
+@@ -385,3 +385,8 @@ global:
+ 	nla_get_uint;
+ 	nla_put_uint;
+ } libnl_3_10;
++
++libnl_3_12 {
++global:
++	nl_cache_resync_v2;
++} libnl_3_11;
+-- 
+2.47.1
+

--- a/recipes-support/libnl/libnl/0004-link-bonding-add-primary-getters-and-setters.patch
+++ b/recipes-support/libnl/libnl/0004-link-bonding-add-primary-getters-and-setters.patch
@@ -1,7 +1,7 @@
-From 8c26319a1a3b404cd96f8a21998f8b6703c39ef2 Mon Sep 17 00:00:00 2001
+From 83c707b7f97961cb8063f8999a88ec72b0678fa6 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 6 Oct 2020 10:00:37 +0200
-Subject: [PATCH 1/7] link/bonding: add primary getters and setters
+Subject: [PATCH 4/9] link/bonding: add primary getters and setters
 
 Add getters and setters for the primary attribute of active backup
 bonds.
@@ -10,8 +10,8 @@ Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
  include/netlink/route/link/bonding.h |  3 ++
  lib/route/link/bonding.c             | 53 ++++++++++++++++++++++++++++
- libnl-route-3.sym                    |  6 ++++
- 3 files changed, 62 insertions(+)
+ libnl-route-3.sym                    |  2 ++
+ 3 files changed, 58 insertions(+)
 
 diff --git a/include/netlink/route/link/bonding.h b/include/netlink/route/link/bonding.h
 index a8dce730279f..4a8cfc546dc6 100644
@@ -134,19 +134,17 @@ index 53b70cae7ed5..db46fb59f6de 100644
   * Set hashing type
   * @arg link            Link object of type bond
 diff --git a/libnl-route-3.sym b/libnl-route-3.sym
-index 75883323c8df..b138b9365e22 100644
+index 17e3fde21e3b..7e89dfd7dbd6 100644
 --- a/libnl-route-3.sym
 +++ b/libnl-route-3.sym
-@@ -1364,3 +1364,9 @@ global:
- 	rtnl_neigh_str2extflag;
- 	rtnl_neigh_unset_ext_flags;
- } libnl_3_10;
-+
-+libnl_3_12 {
-+global:
+@@ -1367,5 +1367,7 @@ global:
+ 
+ libnl_3_12 {
+ global:
 +	rtnl_link_bond_get_primary;
 +	rtnl_link_bond_set_primary;
-+} libnl_3_11;
+ 	rtnl_nh_get_oif;
+ } libnl_3_11;
 -- 
 2.47.1
 

--- a/recipes-support/libnl/libnl/0005-WIP-add-info-slave-data-support.patch
+++ b/recipes-support/libnl/libnl/0005-WIP-add-info-slave-data-support.patch
@@ -1,7 +1,7 @@
-From 5614b2d5b1c67e36783a7d38456cfb040ed1428c Mon Sep 17 00:00:00 2001
+From 8bb6a2e529580a870033fb937a58a07b0b8747ee Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 6 Oct 2020 15:25:38 +0200
-Subject: [PATCH 2/7] WIP: add info slave data support
+Subject: [PATCH 5/9] WIP: add info slave data support
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---

--- a/recipes-support/libnl/libnl/0006-link-bonding-expose-state-on-enslaved-interfaces.patch
+++ b/recipes-support/libnl/libnl/0006-link-bonding-expose-state-on-enslaved-interfaces.patch
@@ -1,7 +1,7 @@
-From 1bc1fbcf07c97726d00b9ff2f0f6f96ec68f5e53 Mon Sep 17 00:00:00 2001
+From 06c18660ce4d5e2a320feb1f7b4fd1de3f149e98 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 6 Oct 2020 16:53:36 +0200
-Subject: [PATCH 3/7] link/bonding: expose state on enslaved interfaces
+Subject: [PATCH 6/9] link/bonding: expose state on enslaved interfaces
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
@@ -227,15 +227,16 @@ index db46fb59f6de..99a9c3db029f 100644
   * Set MII monitoring interval
   * @arg link            Link object of type bond
 diff --git a/libnl-route-3.sym b/libnl-route-3.sym
-index b138b9365e22..f0de995f1eb3 100644
+index 7e89dfd7dbd6..57b2c16cbba9 100644
 --- a/libnl-route-3.sym
 +++ b/libnl-route-3.sym
-@@ -1369,4 +1369,6 @@ libnl_3_12 {
+@@ -1369,5 +1369,7 @@ libnl_3_12 {
  global:
  	rtnl_link_bond_get_primary;
  	rtnl_link_bond_set_primary;
 +	rtnl_link_bond_slave_get_state;
 +	rtnl_link_bond_slave_set_state;
+ 	rtnl_nh_get_oif;
  } libnl_3_11;
 -- 
 2.47.1

--- a/recipes-support/libnl/libnl/0007-bridge-vlan-add-per-vlan-stp-state-object-and-cache.patch
+++ b/recipes-support/libnl/libnl/0007-bridge-vlan-add-per-vlan-stp-state-object-and-cache.patch
@@ -1,7 +1,7 @@
-From 4582cceb65510003ea3b4bc6d18ab71ba577152b Mon Sep 17 00:00:00 2001
+From dc66b44716464f5900e8fd4e442068b063be5d67 Mon Sep 17 00:00:00 2001
 From: Rubens Figueiredo <rubens.figueiredo@bisdn.de>
 Date: Tue, 10 Aug 2021 11:23:39 +0200
-Subject: [PATCH 4/7] bridge-vlan: add per vlan stp state object and cache
+Subject: [PATCH 7/9] bridge-vlan: add per vlan stp state object and cache
 
 Signed-off-by: Rubens Figueiredo <rubens.figueiredo@bisdn.de>
 Co-authored-by: Jonas Gorski <jonas.gorski@bisdn.de>
@@ -589,13 +589,13 @@ index 75f03cd154af..bc10208c8459 100644
 +	nl_cli_bridge_vlan_parse_ifindex;
 +} libnl_3_8;
 diff --git a/libnl-route-3.sym b/libnl-route-3.sym
-index f0de995f1eb3..94fd27ff3f96 100644
+index 57b2c16cbba9..d64eda7e6cd3 100644
 --- a/libnl-route-3.sym
 +++ b/libnl-route-3.sym
-@@ -1371,4 +1371,17 @@ global:
- 	rtnl_link_bond_set_primary;
- 	rtnl_link_bond_slave_get_state;
- 	rtnl_link_bond_slave_set_state;
+@@ -1367,6 +1367,19 @@ global:
+ 
+ libnl_3_12 {
+ global:
 +	rtnl_bridge_vlan_alloc;
 +	rtnl_bridge_vlan_alloc_cache;
 +	rtnl_bridge_vlan_alloc_cache_flags;
@@ -609,7 +609,9 @@ index f0de995f1eb3..94fd27ff3f96 100644
 +	rtnl_bridge_vlan_set_ifindex;
 +	rtnl_bridge_vlan_set_state;
 +	rtnl_bridge_vlan_set_vlan_id;
- } libnl_3_11;
+ 	rtnl_link_bond_get_primary;
+ 	rtnl_link_bond_set_primary;
+ 	rtnl_link_bond_slave_get_state;
 diff --git a/src/lib/bridge_vlan.c b/src/lib/bridge_vlan.c
 new file mode 100644
 index 000000000000..7f90a7f997bd

--- a/recipes-support/libnl/libnl/0008-route-route_obj-treat-each-IPv6-link-local-route-as-.patch
+++ b/recipes-support/libnl/libnl/0008-route-route_obj-treat-each-IPv6-link-local-route-as-.patch
@@ -1,7 +1,7 @@
-From 391eca8addef1fd4a86ff9ed03ad77423d8add13 Mon Sep 17 00:00:00 2001
+From f14eb025ad7c7dd28bea87983f48081b011be92d Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Tue, 1 Mar 2022 12:59:50 +0100
-Subject: [PATCH 5/7] route/route_obj: treat each IPv6 link-local route as
+Subject: [PATCH 8/9] route/route_obj: treat each IPv6 link-local route as
  different
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>

--- a/recipes-support/libnl/libnl/0009-link-ignore-incomplete-bridge-updates.patch
+++ b/recipes-support/libnl/libnl/0009-link-ignore-incomplete-bridge-updates.patch
@@ -1,7 +1,7 @@
-From ce216cd0a69310bfdf86c2eae62f67cf57251b4c Mon Sep 17 00:00:00 2001
+From 5801a620dae397ea63922c20843621d17cff700f Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Wed, 24 Apr 2024 14:13:22 +0200
-Subject: [PATCH 6/7] link: ignore incomplete bridge updates
+Subject: [PATCH 9/9] link: ignore incomplete bridge updates
 
 For currently unknown reasons, the kernel sends a minimal RTM_NEWLINK
 message for a bridge shortly after attaching a port:

--- a/recipes-support/libnl/libnl_3.11.0.bb
+++ b/recipes-support/libnl/libnl_3.11.0.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "http://www.infradead.org/~tgr/libnl/"
 SECTION = "libs/network"
 
 PE = "1"
-PR = "r1"
+PR = "r2"
 
 LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
@@ -14,13 +14,15 @@ DEPENDS = "flex-native bison-native"
 
 SRC_URI = " \
     git://github.com/thom311/${BPN}.git;protocol=https;branch=main \
-    file://0001-link-bonding-add-primary-getters-and-setters.patch \
-    file://0002-WIP-add-info-slave-data-support.patch \
-    file://0003-link-bonding-expose-state-on-enslaved-interfaces.patch \
-    file://0004-bridge-vlan-add-per-vlan-stp-state-object-and-cache.patch \
-    file://0005-route-route_obj-treat-each-IPv6-link-local-route-as-.patch \
-    file://0006-link-ignore-incomplete-bridge-updates.patch \
-    file://0007-cache-cache_include-fix-double-put-for-cloned-object.patch \
+    file://0001-cache-cache_include-fix-double-put-for-cloned-object.patch \
+    file://0002-route-add-missing-rtnl_nh_get_oif-symbol.patch \
+    file://0003-cache-add-nl_cache_resync_v2.patch \
+    file://0004-link-bonding-add-primary-getters-and-setters.patch \
+    file://0005-WIP-add-info-slave-data-support.patch \
+    file://0006-link-bonding-expose-state-on-enslaved-interfaces.patch \
+    file://0007-bridge-vlan-add-per-vlan-stp-state-object-and-cache.patch \
+    file://0008-route-route_obj-treat-each-IPv6-link-local-route-as-.patch \
+    file://0009-link-ignore-incomplete-bridge-updates.patch \
 "
 
 # commit hash of release tag libnl3_11_0


### PR DESCRIPTION
Import two changes from upstream from us:

* fix a missing export of rtnl_nl_get_oif()
* add the missing nl_cache_resync_v2() variant

while at it, reorder the patches so that backports come first, for easier updating/rebasing.