### PR TITLE
baseboxd: update to 2.3.0

### DIFF
--- a/recipes-extended/baseboxd/baseboxd_2.3.0.bb
+++ b/recipes-extended/baseboxd/baseboxd_2.3.0.bb
@@ -4,7 +4,7 @@ inherit meson
 TARGET_LDFLAGS:remove = "-Wl,--as-needed"
 TARGET_LDFLAGS:append = " -Wl,--no-as-needed"
 
-SRCREV = "2fd26c9a56a3fe978766f9dae45fd7f6dd6ed369"
+SRCREV = "ec5fba861b9f50464dc6dcda8d38fd85f69fc5c8"
 
 # install service and sysconfig
 do_install:append() {


### PR DESCRIPTION
Update baseboxd to 2.3.0:

```
ec5fba861b9f Bump version to 2.3.0
1e28461b5fea Merge pull request #457 from bisdn/jogo_port_locked dcab584f6930 cnetlink: ignore locked fdb entries as well 3b3a65e3ccca cnetlink: properly handle ll neigh handable changes a299dd3ee313 nl_bridge: handle port locked
824632b855fc nbi_impl: initialize learning on connect 87b00ee6b64e ofdpa_client: expose per port learning configuration ad2568013a95 proto: update with OF-DPA port learn functions 244e8384fc0d Bump version to 2.2.6
73f69dc02417 Merge pull request #454 from bisdn/jogo_fix_tap_buffer_overrun 3e7e0378baeb tap_io::handle_read_event(): fix potential buffer overrun
```