### PR TITLE
systemd: add support for locking ports

### DIFF
--- a/recipes-core/systemd/files/0001-basic-linux-update-linux-uapi-headers.patch
+++ b/recipes-core/systemd/files/0001-basic-linux-update-linux-uapi-headers.patch
@@ -1,0 +1,2514 @@
+From 442ee8c50d6ed0231348cbff3fcc4477f3588a81 Mon Sep 17 00:00:00 2001
+From: Frantisek Sumsal <frantisek@sumsal.cz>
+Date: Wed, 25 Jan 2023 12:37:49 +0100
+Subject: [PATCH 1/3] basic/linux: update linux uapi headers
+
+IPPROTO_L2TP was moved from linux/l2tp.h to linux/in.h [0], so let's
+reflect that change to fix build with newer kernels:
+
+```
+In file included from ../src/libsystemd/sd-netlink/netlink-types-genl.c:10:
+../src/basic/linux/l2tp.h:16: error: "IPPROTO_L2TP" redefined [-Werror]
+   16 | #define IPPROTO_L2TP            115
+      |
+In file included from ../src/libsystemd/sd-netlink/netlink-types-genl.c:3:
+/usr/include/netinet/in.h:85: note: this is the location of the previous definition
+   85 | #define IPPROTO_L2TP            IPPROTO_L2TP
+      |
+cc1: all warnings being treated as errors
+```
+
+When at it, update the rest of the headers we ship as well.
+
+[0] https://github.com/torvalds/linux/commit/65b32f801bfbc54dc98144a6ec26082b59d131ee
+
+(cherry picked from commit a95ff98ec40edad2825c824a186f44454120cf1f)
+(cherry picked from commit 240513cecaeca035706a618161d0141a9f1267be)
+(cherry picked from commit 4bc291c1d4a97de93eb4015115516d6e7c07da00)
+---
+ src/basic/linux/README                |   1 +
+ src/basic/linux/btrfs.h               | 205 ++++++++++++-
+ src/basic/linux/btrfs_tree.h          | 296 +++++++++++++++++-
+ src/basic/linux/can/netlink.h         |  44 ++-
+ src/basic/linux/genetlink.h           |   5 +-
+ src/basic/linux/if_addr.h             |   9 +-
+ src/basic/linux/if_bridge.h           |  85 ++++++
+ src/basic/linux/if_ether.h            |  10 +-
+ src/basic/linux/if_link.h             | 129 ++++++++
+ src/basic/linux/if_macsec.h           |   2 +
+ src/basic/linux/if_tun.h              |   6 +-
+ src/basic/linux/if_tunnel.h           |   4 +-
+ src/basic/linux/in.h                  |  29 +-
+ src/basic/linux/in6.h                 |   1 +
+ src/basic/linux/l2tp.h                |   2 -
+ src/basic/linux/netfilter/nf_tables.h |  35 ++-
+ src/basic/linux/netlink.h             |  32 +-
+ src/basic/linux/nl80211.h             | 412 ++++++++++++++++++++++++--
+ src/basic/linux/pkt_sched.h           |  15 +
+ src/basic/linux/rtnetlink.h           |  18 +-
+ src/basic/linux/stddef.h              |  46 +++
+ src/basic/linux/update.sh             |   2 +-
+ 22 files changed, 1315 insertions(+), 73 deletions(-)
+ create mode 100644 src/basic/linux/stddef.h
+
+diff --git a/src/basic/linux/README b/src/basic/linux/README
+index 2bb70fdaadb8..1abc9450a6b3 100644
+--- a/src/basic/linux/README
++++ b/src/basic/linux/README
+@@ -4,3 +4,4 @@ The files in this directory are copied from current kernel master
+ modifications are applied:
+ - btrfs.h: drop '__user' attributes
+ - if.h: drop '#include <linux/compiler.h>' and '__user' attributes
++- stddef.h: drop '#include <linux/compiler_types.h>'
+diff --git a/src/basic/linux/btrfs.h b/src/basic/linux/btrfs.h
+index 0f8306fdea64..0a53bdc38a81 100644
+--- a/src/basic/linux/btrfs.h
++++ b/src/basic/linux/btrfs.h
+@@ -19,8 +19,14 @@
+ 
+ #ifndef _UAPI_LINUX_BTRFS_H
+ #define _UAPI_LINUX_BTRFS_H
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
+ #include <linux/types.h>
+ #include <linux/ioctl.h>
++#include <linux/fs.h>
+ 
+ #define BTRFS_IOCTL_MAGIC 0x94
+ #define BTRFS_VOL_NAME_MAX 255
+@@ -93,7 +99,7 @@ struct btrfs_qgroup_inherit {
+ 	__u64	num_ref_copies;
+ 	__u64	num_excl_copies;
+ 	struct btrfs_qgroup_limit lim;
+-	__u64	qgroups[0];
++	__u64	qgroups[];
+ };
+ 
+ struct btrfs_ioctl_qgroup_limit_args {
+@@ -288,6 +294,13 @@ struct btrfs_ioctl_fs_info_args {
+  * first mount when booting older kernel versions.
+  */
+ #define BTRFS_FEATURE_COMPAT_RO_FREE_SPACE_TREE_VALID	(1ULL << 1)
++#define BTRFS_FEATURE_COMPAT_RO_VERITY			(1ULL << 2)
++
++/*
++ * Put all block group items into a dedicated block group tree, greatly
++ * reducing mount time for large filesystem due to better locality.
++ */
++#define BTRFS_FEATURE_COMPAT_RO_BLOCK_GROUP_TREE	(1ULL << 3)
+ 
+ #define BTRFS_FEATURE_INCOMPAT_MIXED_BACKREF	(1ULL << 0)
+ #define BTRFS_FEATURE_INCOMPAT_DEFAULT_SUBVOL	(1ULL << 1)
+@@ -308,6 +321,7 @@ struct btrfs_ioctl_fs_info_args {
+ #define BTRFS_FEATURE_INCOMPAT_METADATA_UUID	(1ULL << 10)
+ #define BTRFS_FEATURE_INCOMPAT_RAID1C34		(1ULL << 11)
+ #define BTRFS_FEATURE_INCOMPAT_ZONED		(1ULL << 12)
++#define BTRFS_FEATURE_INCOMPAT_EXTENT_TREE_V2	(1ULL << 13)
+ 
+ struct btrfs_ioctl_feature_flags {
+ 	__u64 compat_flags;
+@@ -325,6 +339,12 @@ struct btrfs_ioctl_feature_flags {
+  */
+ struct btrfs_balance_args {
+ 	__u64 profiles;
++
++	/*
++	 * usage filter
++	 * BTRFS_BALANCE_ARGS_USAGE with a single value means '0..N'
++	 * BTRFS_BALANCE_ARGS_USAGE_RANGE - range syntax, min..max
++	 */
+ 	union {
+ 		__u64 usage;
+ 		struct {
+@@ -541,7 +561,7 @@ struct btrfs_ioctl_search_header {
+ 	__u64 offset;
+ 	__u32 type;
+ 	__u32 len;
+-};
++} __attribute__ ((__may_alias__));
+ 
+ #define BTRFS_SEARCH_ARGS_BUFSIZE (4096 - sizeof(struct btrfs_ioctl_search_key))
+ /*
+@@ -554,18 +574,23 @@ struct btrfs_ioctl_search_args {
+ 	char buf[BTRFS_SEARCH_ARGS_BUFSIZE];
+ };
+ 
++/*
++ * Extended version of TREE_SEARCH ioctl that can return more than 4k of bytes.
++ * The allocated size of the buffer is set in buf_size.
++ */
+ struct btrfs_ioctl_search_args_v2 {
+ 	struct btrfs_ioctl_search_key key; /* in/out - search parameters */
+ 	__u64 buf_size;		   /* in - size of buffer
+ 					    * out - on EOVERFLOW: needed size
+ 					    *       to store item */
+-	__u64 buf[0];                       /* out - found items */
++	__u64 buf[];                       /* out - found items */
+ };
+ 
++/* With a @src_length of zero, the range from @src_offset->EOF is cloned! */
+ struct btrfs_ioctl_clone_range_args {
+-  __s64 src_fd;
+-  __u64 src_offset, src_length;
+-  __u64 dest_offset;
++	__s64 src_fd;
++	__u64 src_offset, src_length;
++	__u64 dest_offset;
+ };
+ 
+ /*
+@@ -630,7 +655,7 @@ struct btrfs_ioctl_same_args {
+ 	__u16 dest_count;	/* in - total elements in info array */
+ 	__u16 reserved1;
+ 	__u32 reserved2;
+-	struct btrfs_ioctl_same_extent_info info[0];
++	struct btrfs_ioctl_same_extent_info info[];
+ };
+ 
+ struct btrfs_ioctl_space_info {
+@@ -642,7 +667,7 @@ struct btrfs_ioctl_space_info {
+ struct btrfs_ioctl_space_args {
+ 	__u64 space_slots;
+ 	__u64 total_spaces;
+-	struct btrfs_ioctl_space_info spaces[0];
++	struct btrfs_ioctl_space_info spaces[];
+ };
+ 
+ struct btrfs_data_container {
+@@ -650,7 +675,7 @@ struct btrfs_data_container {
+ 	__u32	bytes_missing;	/* out -- additional bytes needed for result */
+ 	__u32	elem_cnt;	/* out */
+ 	__u32	elem_missed;	/* out */
+-	__u64	val[0];		/* out */
++	__u64	val[];		/* out */
+ };
+ 
+ struct btrfs_ioctl_ino_path_args {
+@@ -669,8 +694,11 @@ struct btrfs_ioctl_logical_ino_args {
+ 	/* struct btrfs_data_container	*inodes;	out   */
+ 	__u64				inodes;
+ };
+-/* Return every ref to the extent, not just those containing logical block.
+- * Requires logical == extent bytenr. */
++
++/*
++ * Return every ref to the extent, not just those containing logical block.
++ * Requires logical == extent bytenr.
++ */
+ #define BTRFS_LOGICAL_INO_ARGS_IGNORE_OFFSET	(1ULL << 0)
+ 
+ enum btrfs_dev_stat_values {
+@@ -770,10 +798,24 @@ struct btrfs_ioctl_received_subvol_args {
+  */
+ #define BTRFS_SEND_FLAG_OMIT_END_CMD		0x4
+ 
++/*
++ * Read the protocol version in the structure
++ */
++#define BTRFS_SEND_FLAG_VERSION			0x8
++
++/*
++ * Send compressed data using the ENCODED_WRITE command instead of decompressing
++ * the data and sending it with the WRITE command. This requires protocol
++ * version >= 2.
++ */
++#define BTRFS_SEND_FLAG_COMPRESSED		0x10
++
+ #define BTRFS_SEND_FLAG_MASK \
+ 	(BTRFS_SEND_FLAG_NO_FILE_DATA | \
+ 	 BTRFS_SEND_FLAG_OMIT_STREAM_HEADER | \
+-	 BTRFS_SEND_FLAG_OMIT_END_CMD)
++	 BTRFS_SEND_FLAG_OMIT_END_CMD | \
++	 BTRFS_SEND_FLAG_VERSION | \
++	 BTRFS_SEND_FLAG_COMPRESSED)
+ 
+ struct btrfs_ioctl_send_args {
+ 	__s64 send_fd;			/* in */
+@@ -781,7 +823,8 @@ struct btrfs_ioctl_send_args {
+ 	__u64 *clone_sources;	/* in */
+ 	__u64 parent_root;		/* in */
+ 	__u64 flags;			/* in */
+-	__u64 reserved[4];		/* in */
++	__u32 version;			/* in */
++	__u8  reserved[28];		/* in */
+ };
+ 
+ /*
+@@ -860,6 +903,134 @@ struct btrfs_ioctl_get_subvol_rootref_args {
+ 		__u8 align[7];
+ };
+ 
++/*
++ * Data and metadata for an encoded read or write.
++ *
++ * Encoded I/O bypasses any encoding automatically done by the filesystem (e.g.,
++ * compression). This can be used to read the compressed contents of a file or
++ * write pre-compressed data directly to a file.
++ *
++ * BTRFS_IOC_ENCODED_READ and BTRFS_IOC_ENCODED_WRITE are essentially
++ * preadv/pwritev with additional metadata about how the data is encoded and the
++ * size of the unencoded data.
++ *
++ * BTRFS_IOC_ENCODED_READ fills the given iovecs with the encoded data, fills
++ * the metadata fields, and returns the size of the encoded data. It reads one
++ * extent per call. It can also read data which is not encoded.
++ *
++ * BTRFS_IOC_ENCODED_WRITE uses the metadata fields, writes the encoded data
++ * from the iovecs, and returns the size of the encoded data. Note that the
++ * encoded data is not validated when it is written; if it is not valid (e.g.,
++ * it cannot be decompressed), then a subsequent read may return an error.
++ *
++ * Since the filesystem page cache contains decoded data, encoded I/O bypasses
++ * the page cache. Encoded I/O requires CAP_SYS_ADMIN.
++ */
++struct btrfs_ioctl_encoded_io_args {
++	/* Input parameters for both reads and writes. */
++
++	/*
++	 * iovecs containing encoded data.
++	 *
++	 * For reads, if the size of the encoded data is larger than the sum of
++	 * iov[n].iov_len for 0 <= n < iovcnt, then the ioctl fails with
++	 * ENOBUFS.
++	 *
++	 * For writes, the size of the encoded data is the sum of iov[n].iov_len
++	 * for 0 <= n < iovcnt. This must be less than 128 KiB (this limit may
++	 * increase in the future). This must also be less than or equal to
++	 * unencoded_len.
++	 */
++	const struct iovec *iov;
++	/* Number of iovecs. */
++	unsigned long iovcnt;
++	/*
++	 * Offset in file.
++	 *
++	 * For writes, must be aligned to the sector size of the filesystem.
++	 */
++	__s64 offset;
++	/* Currently must be zero. */
++	__u64 flags;
++
++	/*
++	 * For reads, the following members are output parameters that will
++	 * contain the returned metadata for the encoded data.
++	 * For writes, the following members must be set to the metadata for the
++	 * encoded data.
++	 */
++
++	/*
++	 * Length of the data in the file.
++	 *
++	 * Must be less than or equal to unencoded_len - unencoded_offset. For
++	 * writes, must be aligned to the sector size of the filesystem unless
++	 * the data ends at or beyond the current end of the file.
++	 */
++	__u64 len;
++	/*
++	 * Length of the unencoded (i.e., decrypted and decompressed) data.
++	 *
++	 * For writes, must be no more than 128 KiB (this limit may increase in
++	 * the future). If the unencoded data is actually longer than
++	 * unencoded_len, then it is truncated; if it is shorter, then it is
++	 * extended with zeroes.
++	 */
++	__u64 unencoded_len;
++	/*
++	 * Offset from the first byte of the unencoded data to the first byte of
++	 * logical data in the file.
++	 *
++	 * Must be less than unencoded_len.
++	 */
++	__u64 unencoded_offset;
++	/*
++	 * BTRFS_ENCODED_IO_COMPRESSION_* type.
++	 *
++	 * For writes, must not be BTRFS_ENCODED_IO_COMPRESSION_NONE.
++	 */
++	__u32 compression;
++	/* Currently always BTRFS_ENCODED_IO_ENCRYPTION_NONE. */
++	__u32 encryption;
++	/*
++	 * Reserved for future expansion.
++	 *
++	 * For reads, always returned as zero. Users should check for non-zero
++	 * bytes. If there are any, then the kernel has a newer version of this
++	 * structure with additional information that the user definition is
++	 * missing.
++	 *
++	 * For writes, must be zeroed.
++	 */
++	__u8 reserved[64];
++};
++
++/* Data is not compressed. */
++#define BTRFS_ENCODED_IO_COMPRESSION_NONE 0
++/* Data is compressed as a single zlib stream. */
++#define BTRFS_ENCODED_IO_COMPRESSION_ZLIB 1
++/*
++ * Data is compressed as a single zstd frame with the windowLog compression
++ * parameter set to no more than 17.
++ */
++#define BTRFS_ENCODED_IO_COMPRESSION_ZSTD 2
++/*
++ * Data is compressed sector by sector (using the sector size indicated by the
++ * name of the constant) with LZO1X and wrapped in the format documented in
++ * fs/btrfs/lzo.c. For writes, the compression sector size must match the
++ * filesystem sector size.
++ */
++#define BTRFS_ENCODED_IO_COMPRESSION_LZO_4K 3
++#define BTRFS_ENCODED_IO_COMPRESSION_LZO_8K 4
++#define BTRFS_ENCODED_IO_COMPRESSION_LZO_16K 5
++#define BTRFS_ENCODED_IO_COMPRESSION_LZO_32K 6
++#define BTRFS_ENCODED_IO_COMPRESSION_LZO_64K 7
++#define BTRFS_ENCODED_IO_COMPRESSION_TYPES 8
++
++/* Data is not encrypted. */
++#define BTRFS_ENCODED_IO_ENCRYPTION_NONE 0
++#define BTRFS_ENCODED_IO_ENCRYPTION_TYPES 1
++
+ /* Error codes as returned by the kernel */
+ enum btrfs_err_code {
+ 	BTRFS_ERROR_DEV_RAID1_MIN_NOT_MET = 1,
+@@ -988,5 +1159,13 @@ enum btrfs_err_code {
+ 				struct btrfs_ioctl_ino_lookup_user_args)
+ #define BTRFS_IOC_SNAP_DESTROY_V2 _IOW(BTRFS_IOCTL_MAGIC, 63, \
+ 				struct btrfs_ioctl_vol_args_v2)
++#define BTRFS_IOC_ENCODED_READ _IOR(BTRFS_IOCTL_MAGIC, 64, \
++				    struct btrfs_ioctl_encoded_io_args)
++#define BTRFS_IOC_ENCODED_WRITE _IOW(BTRFS_IOCTL_MAGIC, 64, \
++				     struct btrfs_ioctl_encoded_io_args)
++
++#ifdef __cplusplus
++}
++#endif
+ 
+ #endif /* _UAPI_LINUX_BTRFS_H */
+diff --git a/src/basic/linux/btrfs_tree.h b/src/basic/linux/btrfs_tree.h
+index ccdb40fe40dc..ab38d0f411fa 100644
+--- a/src/basic/linux/btrfs_tree.h
++++ b/src/basic/linux/btrfs_tree.h
+@@ -10,6 +10,23 @@
+ #include <stddef.h>
+ #endif
+ 
++/* ASCII for _BHRfS_M, no terminating nul */
++#define BTRFS_MAGIC 0x4D5F53665248425FULL
++
++#define BTRFS_MAX_LEVEL 8
++
++/*
++ * We can actually store much bigger names, but lets not confuse the rest of
++ * linux.
++ */
++#define BTRFS_NAME_LEN 255
++
++/*
++ * Theoretical limit is larger, but we keep this down to a sane value. That
++ * should limit greatly the possibility of collisions on inode ref items.
++ */
++#define BTRFS_LINK_MAX 65535U
++
+ /*
+  * This header contains the structure definitions and constants used
+  * by file system objects that can be retrieved using
+@@ -53,6 +70,9 @@
+ /* tracks free space in block groups. */
+ #define BTRFS_FREE_SPACE_TREE_OBJECTID 10ULL
+ 
++/* Holds the block group items for extent tree v2. */
++#define BTRFS_BLOCK_GROUP_TREE_OBJECTID 11ULL
++
+ /* device stats in the device tree */
+ #define BTRFS_DEV_STATS_OBJECTID 0ULL
+ 
+@@ -118,12 +138,37 @@
+ #define BTRFS_INODE_REF_KEY		12
+ #define BTRFS_INODE_EXTREF_KEY		13
+ #define BTRFS_XATTR_ITEM_KEY		24
++
++/*
++ * fs verity items are stored under two different key types on disk.
++ * The descriptor items:
++ * [ inode objectid, BTRFS_VERITY_DESC_ITEM_KEY, offset ]
++ *
++ * At offset 0, we store a btrfs_verity_descriptor_item which tracks the size
++ * of the descriptor item and some extra data for encryption.
++ * Starting at offset 1, these hold the generic fs verity descriptor.  The
++ * latter are opaque to btrfs, we just read and write them as a blob for the
++ * higher level verity code.  The most common descriptor size is 256 bytes.
++ *
++ * The merkle tree items:
++ * [ inode objectid, BTRFS_VERITY_MERKLE_ITEM_KEY, offset ]
++ *
++ * These also start at offset 0, and correspond to the merkle tree bytes.  When
++ * fsverity asks for page 0 of the merkle tree, we pull up one page starting at
++ * offset 0 for this key type.  These are also opaque to btrfs, we're blindly
++ * storing whatever fsverity sends down.
++ */
++#define BTRFS_VERITY_DESC_ITEM_KEY	36
++#define BTRFS_VERITY_MERKLE_ITEM_KEY	37
++
+ #define BTRFS_ORPHAN_ITEM_KEY		48
+ /* reserve 2-15 close to the inode for later flexibility */
+ 
+ /*
+  * dir items are the name -> inode pointers in a directory.  There is one
+- * for every name in a directory.
++ * for every name in a directory.  BTRFS_DIR_LOG_ITEM_KEY is no longer used
++ * but it's still defined here for documentation purposes and to help avoid
++ * having its numerical value reused in the future.
+  */
+ #define BTRFS_DIR_LOG_ITEM_KEY  60
+ #define BTRFS_DIR_LOG_INDEX_KEY 72
+@@ -331,6 +376,50 @@ enum btrfs_csum_type {
+ #define BTRFS_FT_SYMLINK	7
+ #define BTRFS_FT_XATTR		8
+ #define BTRFS_FT_MAX		9
++/* Directory contains encrypted data */
++#define BTRFS_FT_ENCRYPTED	0x80
++
++static inline __u8 btrfs_dir_flags_to_ftype(__u8 flags)
++{
++	return flags & ~BTRFS_FT_ENCRYPTED;
++}
++
++/*
++ * Inode flags
++ */
++#define BTRFS_INODE_NODATASUM		(1U << 0)
++#define BTRFS_INODE_NODATACOW		(1U << 1)
++#define BTRFS_INODE_READONLY		(1U << 2)
++#define BTRFS_INODE_NOCOMPRESS		(1U << 3)
++#define BTRFS_INODE_PREALLOC		(1U << 4)
++#define BTRFS_INODE_SYNC		(1U << 5)
++#define BTRFS_INODE_IMMUTABLE		(1U << 6)
++#define BTRFS_INODE_APPEND		(1U << 7)
++#define BTRFS_INODE_NODUMP		(1U << 8)
++#define BTRFS_INODE_NOATIME		(1U << 9)
++#define BTRFS_INODE_DIRSYNC		(1U << 10)
++#define BTRFS_INODE_COMPRESS		(1U << 11)
++
++#define BTRFS_INODE_ROOT_ITEM_INIT	(1U << 31)
++
++#define BTRFS_INODE_FLAG_MASK						\
++	(BTRFS_INODE_NODATASUM |					\
++	 BTRFS_INODE_NODATACOW |					\
++	 BTRFS_INODE_READONLY |						\
++	 BTRFS_INODE_NOCOMPRESS |					\
++	 BTRFS_INODE_PREALLOC |						\
++	 BTRFS_INODE_SYNC |						\
++	 BTRFS_INODE_IMMUTABLE |					\
++	 BTRFS_INODE_APPEND |						\
++	 BTRFS_INODE_NODUMP |						\
++	 BTRFS_INODE_NOATIME |						\
++	 BTRFS_INODE_DIRSYNC |						\
++	 BTRFS_INODE_COMPRESS |						\
++	 BTRFS_INODE_ROOT_ITEM_INIT)
++
++#define BTRFS_INODE_RO_VERITY		(1U << 0)
++
++#define BTRFS_INODE_RO_FLAG_MASK	(BTRFS_INODE_RO_VERITY)
+ 
+ /*
+  * The key defines the order in the tree, and so it also defines (optimal)
+@@ -361,6 +450,109 @@ struct btrfs_key {
+ 	__u64 offset;
+ } __attribute__ ((__packed__));
+ 
++/*
++ * Every tree block (leaf or node) starts with this header.
++ */
++struct btrfs_header {
++	/* These first four must match the super block */
++	__u8 csum[BTRFS_CSUM_SIZE];
++	/* FS specific uuid */
++	__u8 fsid[BTRFS_FSID_SIZE];
++	/* Which block this node is supposed to live in */
++	__le64 bytenr;
++	__le64 flags;
++
++	/* Allowed to be different from the super from here on down */
++	__u8 chunk_tree_uuid[BTRFS_UUID_SIZE];
++	__le64 generation;
++	__le64 owner;
++	__le32 nritems;
++	__u8 level;
++} __attribute__ ((__packed__));
++
++/*
++ * This is a very generous portion of the super block, giving us room to
++ * translate 14 chunks with 3 stripes each.
++ */
++#define BTRFS_SYSTEM_CHUNK_ARRAY_SIZE 2048
++
++/*
++ * Just in case we somehow lose the roots and are not able to mount, we store
++ * an array of the roots from previous transactions in the super.
++ */
++#define BTRFS_NUM_BACKUP_ROOTS 4
++struct btrfs_root_backup {
++	__le64 tree_root;
++	__le64 tree_root_gen;
++
++	__le64 chunk_root;
++	__le64 chunk_root_gen;
++
++	__le64 extent_root;
++	__le64 extent_root_gen;
++
++	__le64 fs_root;
++	__le64 fs_root_gen;
++
++	__le64 dev_root;
++	__le64 dev_root_gen;
++
++	__le64 csum_root;
++	__le64 csum_root_gen;
++
++	__le64 total_bytes;
++	__le64 bytes_used;
++	__le64 num_devices;
++	/* future */
++	__le64 unused_64[4];
++
++	__u8 tree_root_level;
++	__u8 chunk_root_level;
++	__u8 extent_root_level;
++	__u8 fs_root_level;
++	__u8 dev_root_level;
++	__u8 csum_root_level;
++	/* future and to align */
++	__u8 unused_8[10];
++} __attribute__ ((__packed__));
++
++/*
++ * A leaf is full of items. offset and size tell us where to find the item in
++ * the leaf (relative to the start of the data area)
++ */
++struct btrfs_item {
++	struct btrfs_disk_key key;
++	__le32 offset;
++	__le32 size;
++} __attribute__ ((__packed__));
++
++/*
++ * Leaves have an item area and a data area:
++ * [item0, item1....itemN] [free space] [dataN...data1, data0]
++ *
++ * The data is separate from the items to get the keys closer together during
++ * searches.
++ */
++struct btrfs_leaf {
++	struct btrfs_header header;
++	struct btrfs_item items[];
++} __attribute__ ((__packed__));
++
++/*
++ * All non-leaf blocks are nodes, they hold only keys and pointers to other
++ * blocks.
++ */
++struct btrfs_key_ptr {
++	struct btrfs_disk_key key;
++	__le64 blockptr;
++	__le64 generation;
++} __attribute__ ((__packed__));
++
++struct btrfs_node {
++	struct btrfs_header header;
++	struct btrfs_key_ptr ptrs[];
++} __attribute__ ((__packed__));
++
+ struct btrfs_dev_item {
+ 	/* the internal btrfs device id */
+ 	__le64 devid;
+@@ -444,6 +636,69 @@ struct btrfs_chunk {
+ 	/* additional stripes go here */
+ } __attribute__ ((__packed__));
+ 
++/*
++ * The super block basically lists the main trees of the FS.
++ */
++struct btrfs_super_block {
++	/* The first 4 fields must match struct btrfs_header */
++	__u8 csum[BTRFS_CSUM_SIZE];
++	/* FS specific UUID, visible to user */
++	__u8 fsid[BTRFS_FSID_SIZE];
++	/* This block number */
++	__le64 bytenr;
++	__le64 flags;
++
++	/* Allowed to be different from the btrfs_header from here own down */
++	__le64 magic;
++	__le64 generation;
++	__le64 root;
++	__le64 chunk_root;
++	__le64 log_root;
++
++	/*
++	 * This member has never been utilized since the very beginning, thus
++	 * it's always 0 regardless of kernel version.  We always use
++	 * generation + 1 to read log tree root.  So here we mark it deprecated.
++	 */
++	__le64 __unused_log_root_transid;
++	__le64 total_bytes;
++	__le64 bytes_used;
++	__le64 root_dir_objectid;
++	__le64 num_devices;
++	__le32 sectorsize;
++	__le32 nodesize;
++	__le32 __unused_leafsize;
++	__le32 stripesize;
++	__le32 sys_chunk_array_size;
++	__le64 chunk_root_generation;
++	__le64 compat_flags;
++	__le64 compat_ro_flags;
++	__le64 incompat_flags;
++	__le16 csum_type;
++	__u8 root_level;
++	__u8 chunk_root_level;
++	__u8 log_root_level;
++	struct btrfs_dev_item dev_item;
++
++	char label[BTRFS_LABEL_SIZE];
++
++	__le64 cache_generation;
++	__le64 uuid_tree_generation;
++
++	/* The UUID written into btree blocks */
++	__u8 metadata_uuid[BTRFS_FSID_SIZE];
++
++	__u64 nr_global_roots;
++
++	/* Future expansion */
++	__le64 reserved[27];
++	__u8 sys_chunk_array[BTRFS_SYSTEM_CHUNK_ARRAY_SIZE];
++	struct btrfs_root_backup super_roots[BTRFS_NUM_BACKUP_ROOTS];
++
++	/* Padded to 4096 bytes */
++	__u8 padding[565];
++} __attribute__ ((__packed__));
++
+ #define BTRFS_FREE_SPACE_EXTENT	1
+ #define BTRFS_FREE_SPACE_BITMAP	2
+ 
+@@ -498,6 +753,14 @@ struct btrfs_extent_item_v0 {
+ /* use full backrefs for extent pointers in the block */
+ #define BTRFS_BLOCK_FLAG_FULL_BACKREF	(1ULL << 8)
+ 
++#define BTRFS_BACKREF_REV_MAX		256
++#define BTRFS_BACKREF_REV_SHIFT		56
++#define BTRFS_BACKREF_REV_MASK		(((u64)BTRFS_BACKREF_REV_MAX - 1) << \
++					 BTRFS_BACKREF_REV_SHIFT)
++
++#define BTRFS_OLD_BACKREF_REV		0
++#define BTRFS_MIXED_BACKREF_REV		1
++
+ /*
+  * this flag is only used internally by scrub and may be changed at any time
+  * it is only declared here to avoid collisions
+@@ -547,7 +810,7 @@ struct btrfs_inode_extref {
+ 	__le64 parent_objectid;
+ 	__le64 index;
+ 	__le16 name_len;
+-	__u8   name[0];
++	__u8   name[];
+ 	/* name goes here */
+ } __attribute__ ((__packed__));
+ 
+@@ -852,19 +1115,6 @@ struct btrfs_dev_replace_item {
+ #define BTRFS_BLOCK_GROUP_RESERVED	(BTRFS_AVAIL_ALLOC_BIT_SINGLE | \
+ 					 BTRFS_SPACE_INFO_GLOBAL_RSV)
+ 
+-enum btrfs_raid_types {
+-	BTRFS_RAID_RAID10,
+-	BTRFS_RAID_RAID1,
+-	BTRFS_RAID_DUP,
+-	BTRFS_RAID_RAID0,
+-	BTRFS_RAID_SINGLE,
+-	BTRFS_RAID_RAID5,
+-	BTRFS_RAID_RAID6,
+-	BTRFS_RAID_RAID1C3,
+-	BTRFS_RAID_RAID1C4,
+-	BTRFS_NR_RAID_TYPES
+-};
+-
+ #define BTRFS_BLOCK_GROUP_TYPE_MASK	(BTRFS_BLOCK_GROUP_DATA |    \
+ 					 BTRFS_BLOCK_GROUP_SYSTEM |  \
+ 					 BTRFS_BLOCK_GROUP_METADATA)
+@@ -950,6 +1200,10 @@ static inline __u16 btrfs_qgroup_level(__u64 qgroupid)
+  */
+ #define BTRFS_QGROUP_STATUS_FLAG_INCONSISTENT	(1ULL << 2)
+ 
++#define BTRFS_QGROUP_STATUS_FLAGS_MASK	(BTRFS_QGROUP_STATUS_FLAG_ON |		\
++					 BTRFS_QGROUP_STATUS_FLAG_RESCAN |	\
++					 BTRFS_QGROUP_STATUS_FLAG_INCONSISTENT)
++
+ #define BTRFS_QGROUP_STATUS_VERSION        1
+ 
+ struct btrfs_qgroup_status_item {
+@@ -991,4 +1245,16 @@ struct btrfs_qgroup_limit_item {
+ 	__le64 rsv_excl;
+ } __attribute__ ((__packed__));
+ 
++struct btrfs_verity_descriptor_item {
++	/* Size of the verity descriptor in bytes */
++	__le64 size;
++	/*
++	 * When we implement support for fscrypt, we will need to encrypt the
++	 * Merkle tree for encrypted verity files. These 128 bits are for the
++	 * eventual storage of an fscrypt initialization vector.
++	 */
++	__le64 reserved[2];
++	__u8 encryption;
++} __attribute__ ((__packed__));
++
+ #endif /* _BTRFS_CTREE_H_ */
+diff --git a/src/basic/linux/can/netlink.h b/src/basic/linux/can/netlink.h
+index f730d443b918..02ec32d69474 100644
+--- a/src/basic/linux/can/netlink.h
++++ b/src/basic/linux/can/netlink.h
+@@ -101,6 +101,8 @@ struct can_ctrlmode {
+ #define CAN_CTRLMODE_PRESUME_ACK	0x40	/* Ignore missing CAN ACKs */
+ #define CAN_CTRLMODE_FD_NON_ISO		0x80	/* CAN FD in non-ISO mode */
+ #define CAN_CTRLMODE_CC_LEN8_DLC	0x100	/* Classic CAN DLC option */
++#define CAN_CTRLMODE_TDC_AUTO		0x200	/* CAN transiver automatically calculates TDCV */
++#define CAN_CTRLMODE_TDC_MANUAL		0x400	/* TDCV is manually set up by user */
+ 
+ /*
+  * CAN device statistics
+@@ -134,10 +136,48 @@ enum {
+ 	IFLA_CAN_BITRATE_CONST,
+ 	IFLA_CAN_DATA_BITRATE_CONST,
+ 	IFLA_CAN_BITRATE_MAX,
+-	__IFLA_CAN_MAX
++	IFLA_CAN_TDC,
++	IFLA_CAN_CTRLMODE_EXT,
++
++	/* add new constants above here */
++	__IFLA_CAN_MAX,
++	IFLA_CAN_MAX = __IFLA_CAN_MAX - 1
+ };
+ 
+-#define IFLA_CAN_MAX	(__IFLA_CAN_MAX - 1)
++/*
++ * CAN FD Transmitter Delay Compensation (TDC)
++ *
++ * Please refer to struct can_tdc_const and can_tdc in
++ * include/linux/can/bittiming.h for further details.
++ */
++enum {
++	IFLA_CAN_TDC_UNSPEC,
++	IFLA_CAN_TDC_TDCV_MIN,	/* u32 */
++	IFLA_CAN_TDC_TDCV_MAX,	/* u32 */
++	IFLA_CAN_TDC_TDCO_MIN,	/* u32 */
++	IFLA_CAN_TDC_TDCO_MAX,	/* u32 */
++	IFLA_CAN_TDC_TDCF_MIN,	/* u32 */
++	IFLA_CAN_TDC_TDCF_MAX,	/* u32 */
++	IFLA_CAN_TDC_TDCV,	/* u32 */
++	IFLA_CAN_TDC_TDCO,	/* u32 */
++	IFLA_CAN_TDC_TDCF,	/* u32 */
++
++	/* add new constants above here */
++	__IFLA_CAN_TDC,
++	IFLA_CAN_TDC_MAX = __IFLA_CAN_TDC - 1
++};
++
++/*
++ * IFLA_CAN_CTRLMODE_EXT nest: controller mode extended parameters
++ */
++enum {
++	IFLA_CAN_CTRLMODE_UNSPEC,
++	IFLA_CAN_CTRLMODE_SUPPORTED,	/* u32 */
++
++	/* add new constants above here */
++	__IFLA_CAN_CTRLMODE,
++	IFLA_CAN_CTRLMODE_MAX = __IFLA_CAN_CTRLMODE - 1
++};
+ 
+ /* u16 termination range: 1..65535 Ohms */
+ #define CAN_TERMINATION_DISABLED 0
+diff --git a/src/basic/linux/genetlink.h b/src/basic/linux/genetlink.h
+index d83f214b4134..ddba3ca01e39 100644
+--- a/src/basic/linux/genetlink.h
++++ b/src/basic/linux/genetlink.h
+@@ -87,6 +87,8 @@ enum {
+ 	__CTRL_ATTR_MCAST_GRP_MAX,
+ };
+ 
++#define CTRL_ATTR_MCAST_GRP_MAX (__CTRL_ATTR_MCAST_GRP_MAX - 1)
++
+ enum {
+ 	CTRL_ATTR_POLICY_UNSPEC,
+ 	CTRL_ATTR_POLICY_DO,
+@@ -96,7 +98,6 @@ enum {
+ 	CTRL_ATTR_POLICY_DUMP_MAX = __CTRL_ATTR_POLICY_DUMP_MAX - 1
+ };
+ 
+-#define CTRL_ATTR_MCAST_GRP_MAX (__CTRL_ATTR_MCAST_GRP_MAX - 1)
+-
++#define CTRL_ATTR_POLICY_MAX (__CTRL_ATTR_POLICY_DUMP_MAX - 1)
+ 
+ #endif /* _UAPI__LINUX_GENERIC_NETLINK_H */
+diff --git a/src/basic/linux/if_addr.h b/src/basic/linux/if_addr.h
+index dfcf3ce0097f..1c392dd95a5e 100644
+--- a/src/basic/linux/if_addr.h
++++ b/src/basic/linux/if_addr.h
+@@ -33,8 +33,9 @@ enum {
+ 	IFA_CACHEINFO,
+ 	IFA_MULTICAST,
+ 	IFA_FLAGS,
+-	IFA_RT_PRIORITY,  /* u32, priority/metric for prefix route */
++	IFA_RT_PRIORITY,	/* u32, priority/metric for prefix route */
+ 	IFA_TARGET_NETNSID,
++	IFA_PROTO,		/* u8, address protocol */
+ 	__IFA_MAX,
+ };
+ 
+@@ -69,4 +70,10 @@ struct ifa_cacheinfo {
+ #define IFA_PAYLOAD(n) NLMSG_PAYLOAD(n,sizeof(struct ifaddrmsg))
+ #endif
+ 
++/* ifa_proto */
++#define IFAPROT_UNSPEC		0
++#define IFAPROT_KERNEL_LO	1	/* loopback */
++#define IFAPROT_KERNEL_RA	2	/* set by kernel from router announcement */
++#define IFAPROT_KERNEL_LL	3	/* link-local set by kernel */
++
+ #endif
+diff --git a/src/basic/linux/if_bridge.h b/src/basic/linux/if_bridge.h
+index 6b56a7549531..d9de241d90f9 100644
+--- a/src/basic/linux/if_bridge.h
++++ b/src/basic/linux/if_bridge.h
+@@ -122,6 +122,7 @@ enum {
+ 	IFLA_BRIDGE_VLAN_TUNNEL_INFO,
+ 	IFLA_BRIDGE_MRP,
+ 	IFLA_BRIDGE_CFM,
++	IFLA_BRIDGE_MST,
+ 	__IFLA_BRIDGE_MAX,
+ };
+ #define IFLA_BRIDGE_MAX (__IFLA_BRIDGE_MAX - 1)
+@@ -453,6 +454,21 @@ enum {
+ 
+ #define IFLA_BRIDGE_CFM_CC_PEER_STATUS_MAX (__IFLA_BRIDGE_CFM_CC_PEER_STATUS_MAX - 1)
+ 
++enum {
++	IFLA_BRIDGE_MST_UNSPEC,
++	IFLA_BRIDGE_MST_ENTRY,
++	__IFLA_BRIDGE_MST_MAX,
++};
++#define IFLA_BRIDGE_MST_MAX (__IFLA_BRIDGE_MST_MAX - 1)
++
++enum {
++	IFLA_BRIDGE_MST_ENTRY_UNSPEC,
++	IFLA_BRIDGE_MST_ENTRY_MSTI,
++	IFLA_BRIDGE_MST_ENTRY_STATE,
++	__IFLA_BRIDGE_MST_ENTRY_MAX,
++};
++#define IFLA_BRIDGE_MST_ENTRY_MAX (__IFLA_BRIDGE_MST_ENTRY_MAX - 1)
++
+ struct bridge_stp_xstats {
+ 	__u64 transition_blk;
+ 	__u64 transition_fwd;
+@@ -479,16 +495,22 @@ enum {
+ 
+ /* flags used in BRIDGE_VLANDB_DUMP_FLAGS attribute to affect dumps */
+ #define BRIDGE_VLANDB_DUMPF_STATS	(1 << 0) /* Include stats in the dump */
++#define BRIDGE_VLANDB_DUMPF_GLOBAL	(1 << 1) /* Dump global vlan options only */
+ 
+ /* Bridge vlan RTM attributes
+  * [BRIDGE_VLANDB_ENTRY] = {
+  *     [BRIDGE_VLANDB_ENTRY_INFO]
+  *     ...
+  * }
++ * [BRIDGE_VLANDB_GLOBAL_OPTIONS] = {
++ *     [BRIDGE_VLANDB_GOPTS_ID]
++ *     ...
++ * }
+  */
+ enum {
+ 	BRIDGE_VLANDB_UNSPEC,
+ 	BRIDGE_VLANDB_ENTRY,
++	BRIDGE_VLANDB_GLOBAL_OPTIONS,
+ 	__BRIDGE_VLANDB_MAX,
+ };
+ #define BRIDGE_VLANDB_MAX (__BRIDGE_VLANDB_MAX - 1)
+@@ -500,6 +522,7 @@ enum {
+ 	BRIDGE_VLANDB_ENTRY_STATE,
+ 	BRIDGE_VLANDB_ENTRY_TUNNEL_INFO,
+ 	BRIDGE_VLANDB_ENTRY_STATS,
++	BRIDGE_VLANDB_ENTRY_MCAST_ROUTER,
+ 	__BRIDGE_VLANDB_ENTRY_MAX,
+ };
+ #define BRIDGE_VLANDB_ENTRY_MAX (__BRIDGE_VLANDB_ENTRY_MAX - 1)
+@@ -538,6 +561,30 @@ enum {
+ };
+ #define BRIDGE_VLANDB_STATS_MAX (__BRIDGE_VLANDB_STATS_MAX - 1)
+ 
++enum {
++	BRIDGE_VLANDB_GOPTS_UNSPEC,
++	BRIDGE_VLANDB_GOPTS_ID,
++	BRIDGE_VLANDB_GOPTS_RANGE,
++	BRIDGE_VLANDB_GOPTS_MCAST_SNOOPING,
++	BRIDGE_VLANDB_GOPTS_MCAST_IGMP_VERSION,
++	BRIDGE_VLANDB_GOPTS_MCAST_MLD_VERSION,
++	BRIDGE_VLANDB_GOPTS_MCAST_LAST_MEMBER_CNT,
++	BRIDGE_VLANDB_GOPTS_MCAST_STARTUP_QUERY_CNT,
++	BRIDGE_VLANDB_GOPTS_MCAST_LAST_MEMBER_INTVL,
++	BRIDGE_VLANDB_GOPTS_PAD,
++	BRIDGE_VLANDB_GOPTS_MCAST_MEMBERSHIP_INTVL,
++	BRIDGE_VLANDB_GOPTS_MCAST_QUERIER_INTVL,
++	BRIDGE_VLANDB_GOPTS_MCAST_QUERY_INTVL,
++	BRIDGE_VLANDB_GOPTS_MCAST_QUERY_RESPONSE_INTVL,
++	BRIDGE_VLANDB_GOPTS_MCAST_STARTUP_QUERY_INTVL,
++	BRIDGE_VLANDB_GOPTS_MCAST_QUERIER,
++	BRIDGE_VLANDB_GOPTS_MCAST_ROUTER_PORTS,
++	BRIDGE_VLANDB_GOPTS_MCAST_QUERIER_STATE,
++	BRIDGE_VLANDB_GOPTS_MSTI,
++	__BRIDGE_VLANDB_GOPTS_MAX
++};
++#define BRIDGE_VLANDB_GOPTS_MAX (__BRIDGE_VLANDB_GOPTS_MAX - 1)
++
+ /* Bridge multicast database attributes
+  * [MDBA_MDB] = {
+  *     [MDBA_MDB_ENTRY] = {
+@@ -629,6 +676,7 @@ enum {
+ 	MDBA_ROUTER_PATTR_TYPE,
+ 	MDBA_ROUTER_PATTR_INET_TIMER,
+ 	MDBA_ROUTER_PATTR_INET6_TIMER,
++	MDBA_ROUTER_PATTR_VID,
+ 	__MDBA_ROUTER_PATTR_MAX
+ };
+ #define MDBA_ROUTER_PATTR_MAX (__MDBA_ROUTER_PATTR_MAX - 1)
+@@ -675,10 +723,31 @@ enum {
+ enum {
+ 	MDBE_ATTR_UNSPEC,
+ 	MDBE_ATTR_SOURCE,
++	MDBE_ATTR_SRC_LIST,
++	MDBE_ATTR_GROUP_MODE,
++	MDBE_ATTR_RTPROT,
+ 	__MDBE_ATTR_MAX,
+ };
+ #define MDBE_ATTR_MAX (__MDBE_ATTR_MAX - 1)
+ 
++/* per mdb entry source */
++enum {
++	MDBE_SRC_LIST_UNSPEC,
++	MDBE_SRC_LIST_ENTRY,
++	__MDBE_SRC_LIST_MAX,
++};
++#define MDBE_SRC_LIST_MAX (__MDBE_SRC_LIST_MAX - 1)
++
++/* per mdb entry per source attributes
++ * these are embedded in MDBE_SRC_LIST_ENTRY
++ */
++enum {
++	MDBE_SRCATTR_UNSPEC,
++	MDBE_SRCATTR_ADDRESS,
++	__MDBE_SRCATTR_MAX,
++};
++#define MDBE_SRCATTR_MAX (__MDBE_SRCATTR_MAX - 1)
++
+ /* Embedded inside LINK_XSTATS_TYPE_BRIDGE */
+ enum {
+ 	BRIDGE_XSTATS_UNSPEC,
+@@ -720,12 +789,15 @@ struct br_mcast_stats {
+ 
+ /* bridge boolean options
+  * BR_BOOLOPT_NO_LL_LEARN - disable learning from link-local packets
++ * BR_BOOLOPT_MCAST_VLAN_SNOOPING - control vlan multicast snooping
+  *
+  * IMPORTANT: if adding a new option do not forget to handle
+  *            it in br_boolopt_toggle/get and bridge sysfs
+  */
+ enum br_boolopt_id {
+ 	BR_BOOLOPT_NO_LL_LEARN,
++	BR_BOOLOPT_MCAST_VLAN_SNOOPING,
++	BR_BOOLOPT_MST_ENABLE,
+ 	BR_BOOLOPT_MAX
+ };
+ 
+@@ -738,4 +810,17 @@ struct br_boolopt_multi {
+ 	__u32 optval;
+ 	__u32 optmask;
+ };
++
++enum {
++	BRIDGE_QUERIER_UNSPEC,
++	BRIDGE_QUERIER_IP_ADDRESS,
++	BRIDGE_QUERIER_IP_PORT,
++	BRIDGE_QUERIER_IP_OTHER_TIMER,
++	BRIDGE_QUERIER_PAD,
++	BRIDGE_QUERIER_IPV6_ADDRESS,
++	BRIDGE_QUERIER_IPV6_PORT,
++	BRIDGE_QUERIER_IPV6_OTHER_TIMER,
++	__BRIDGE_QUERIER_MAX
++};
++#define BRIDGE_QUERIER_MAX (__BRIDGE_QUERIER_MAX - 1)
+ #endif /* _UAPI_LINUX_IF_BRIDGE_H */
+diff --git a/src/basic/linux/if_ether.h b/src/basic/linux/if_ether.h
+index a0b637911d3c..69e0457eb200 100644
+--- a/src/basic/linux/if_ether.h
++++ b/src/basic/linux/if_ether.h
+@@ -86,7 +86,10 @@
+ 					 * over Ethernet
+ 					 */
+ #define ETH_P_PAE	0x888E		/* Port Access Entity (IEEE 802.1X) */
++#define ETH_P_PROFINET	0x8892		/* PROFINET			*/
++#define ETH_P_REALTEK	0x8899          /* Multiple proprietary protocols */
+ #define ETH_P_AOE	0x88A2		/* ATA over Ethernet		*/
++#define ETH_P_ETHERCAT	0x88A4		/* EtherCAT			*/
+ #define ETH_P_8021AD	0x88A8          /* 802.1ad Service VLAN		*/
+ #define ETH_P_802_EX1	0x88B5		/* 802.1 Local Experimental 1.  */
+ #define ETH_P_PREAUTH	0x88C7		/* 802.11 Preauthentication */
+@@ -113,10 +116,11 @@
+ #define ETH_P_QINQ3	0x9300		/* deprecated QinQ VLAN [ NOT AN OFFICIALLY REGISTERED ID ] */
+ #define ETH_P_EDSA	0xDADA		/* Ethertype DSA [ NOT AN OFFICIALLY REGISTERED ID ] */
+ #define ETH_P_DSA_8021Q	0xDADB		/* Fake VLAN Header for DSA [ NOT AN OFFICIALLY REGISTERED ID ] */
++#define ETH_P_DSA_A5PSW	0xE001		/* A5PSW Tag Value [ NOT AN OFFICIALLY REGISTERED ID ] */
+ #define ETH_P_IFE	0xED3E		/* ForCES inter-FE LFB type */
+ #define ETH_P_AF_IUCV   0xFBFB		/* IBM af_iucv [ NOT AN OFFICIALLY REGISTERED ID ] */
+ 
+-#define ETH_P_802_3_MIN	0x0600		/* If the value in the ethernet type is less than this value
++#define ETH_P_802_3_MIN	0x0600		/* If the value in the ethernet type is more than this value
+ 					 * then the frame is Ethernet II. Else it is 802.3 */
+ 
+ /*
+@@ -134,6 +138,7 @@
+ #define ETH_P_LOCALTALK 0x0009		/* Localtalk pseudo type 	*/
+ #define ETH_P_CAN	0x000C		/* CAN: Controller Area Network */
+ #define ETH_P_CANFD	0x000D		/* CANFD: CAN flexible data rate*/
++#define ETH_P_CANXL	0x000E		/* CANXL: eXtended frame Length */
+ #define ETH_P_PPPTALK	0x0010		/* Dummy type for Atalk over PPP*/
+ #define ETH_P_TR_802_2	0x0011		/* 802.2 frames 		*/
+ #define ETH_P_MOBITEX	0x0015		/* Mobitex (kaz@cafe.net)	*/
+@@ -151,6 +156,9 @@
+ #define ETH_P_MAP	0x00F9		/* Qualcomm multiplexing and
+ 					 * aggregation protocol
+ 					 */
++#define ETH_P_MCTP	0x00FA		/* Management component transport
++					 * protocol packets
++					 */
+ 
+ /*
+  *	This is an Ethernet frame header.
+diff --git a/src/basic/linux/if_link.h b/src/basic/linux/if_link.h
+index 4882e81514b6..1021a7e47a86 100644
+--- a/src/basic/linux/if_link.h
++++ b/src/basic/linux/if_link.h
+@@ -211,6 +211,9 @@ struct rtnl_link_stats {
+  * @rx_nohandler: Number of packets received on the interface
+  *   but dropped by the networking stack because the device is
+  *   not designated to receive packets (e.g. backup link in a bond).
++ *
++ * @rx_otherhost_dropped: Number of packets dropped due to mismatch
++ *   in destination MAC address.
+  */
+ struct rtnl_link_stats64 {
+ 	__u64	rx_packets;
+@@ -243,6 +246,23 @@ struct rtnl_link_stats64 {
+ 	__u64	rx_compressed;
+ 	__u64	tx_compressed;
+ 	__u64	rx_nohandler;
++
++	__u64	rx_otherhost_dropped;
++};
++
++/* Subset of link stats useful for in-HW collection. Meaning of the fields is as
++ * for struct rtnl_link_stats64.
++ */
++struct rtnl_hw_stats64 {
++	__u64	rx_packets;
++	__u64	tx_packets;
++	__u64	rx_bytes;
++	__u64	tx_bytes;
++	__u64	rx_errors;
++	__u64	tx_errors;
++	__u64	rx_dropped;
++	__u64	tx_dropped;
++	__u64	multicast;
+ };
+ 
+ /* The struct should be in sync with struct ifmap */
+@@ -347,6 +367,12 @@ enum {
+ 	 */
+ 	IFLA_PARENT_DEV_NAME,
+ 	IFLA_PARENT_DEV_BUS_NAME,
++	IFLA_GRO_MAX_SIZE,
++	IFLA_TSO_MAX_SIZE,
++	IFLA_TSO_MAX_SEGS,
++	IFLA_ALLMULTI,		/* Allmulti count: > 0 means acts ALLMULTI */
++
++	IFLA_DEVLINK_PORT,
+ 
+ 	__IFLA_MAX
+ };
+@@ -417,6 +443,7 @@ enum {
+ 	IFLA_INET6_ICMP6STATS,	/* statistics (icmpv6)		*/
+ 	IFLA_INET6_TOKEN,	/* device token			*/
+ 	IFLA_INET6_ADDR_GEN_MODE, /* implicit address generator mode */
++	IFLA_INET6_RA_MTU,	/* mtu carried in the RA message */
+ 	__IFLA_INET6_MAX
+ };
+ 
+@@ -479,6 +506,7 @@ enum {
+ 	IFLA_BR_MCAST_MLD_VERSION,
+ 	IFLA_BR_VLAN_STATS_PER_PORT,
+ 	IFLA_BR_MULTI_BOOLOPT,
++	IFLA_BR_MCAST_QUERIER_STATE,
+ 	__IFLA_BR_MAX,
+ };
+ 
+@@ -534,6 +562,8 @@ enum {
+ 	IFLA_BRPORT_MRP_IN_OPEN,
+ 	IFLA_BRPORT_MCAST_EHT_HOSTS_LIMIT,
+ 	IFLA_BRPORT_MCAST_EHT_HOSTS_CNT,
++	IFLA_BRPORT_LOCKED,
++	IFLA_BRPORT_MAB,
+ 	__IFLA_BRPORT_MAX
+ };
+ #define IFLA_BRPORT_MAX (__IFLA_BRPORT_MAX - 1)
+@@ -668,6 +698,7 @@ enum {
+ 	IFLA_XFRM_UNSPEC,
+ 	IFLA_XFRM_LINK,
+ 	IFLA_XFRM_IF_ID,
++	IFLA_XFRM_COLLECT_METADATA,
+ 	__IFLA_XFRM_MAX
+ };
+ 
+@@ -709,7 +740,55 @@ enum ipvlan_mode {
+ #define IPVLAN_F_PRIVATE	0x01
+ #define IPVLAN_F_VEPA		0x02
+ 
++/* Tunnel RTM header */
++struct tunnel_msg {
++	__u8 family;
++	__u8 flags;
++	__u16 reserved2;
++	__u32 ifindex;
++};
++
+ /* VXLAN section */
++
++/* include statistics in the dump */
++#define TUNNEL_MSG_FLAG_STATS	0x01
++
++#define TUNNEL_MSG_VALID_USER_FLAGS TUNNEL_MSG_FLAG_STATS
++
++/* Embedded inside VXLAN_VNIFILTER_ENTRY_STATS */
++enum {
++	VNIFILTER_ENTRY_STATS_UNSPEC,
++	VNIFILTER_ENTRY_STATS_RX_BYTES,
++	VNIFILTER_ENTRY_STATS_RX_PKTS,
++	VNIFILTER_ENTRY_STATS_RX_DROPS,
++	VNIFILTER_ENTRY_STATS_RX_ERRORS,
++	VNIFILTER_ENTRY_STATS_TX_BYTES,
++	VNIFILTER_ENTRY_STATS_TX_PKTS,
++	VNIFILTER_ENTRY_STATS_TX_DROPS,
++	VNIFILTER_ENTRY_STATS_TX_ERRORS,
++	VNIFILTER_ENTRY_STATS_PAD,
++	__VNIFILTER_ENTRY_STATS_MAX
++};
++#define VNIFILTER_ENTRY_STATS_MAX (__VNIFILTER_ENTRY_STATS_MAX - 1)
++
++enum {
++	VXLAN_VNIFILTER_ENTRY_UNSPEC,
++	VXLAN_VNIFILTER_ENTRY_START,
++	VXLAN_VNIFILTER_ENTRY_END,
++	VXLAN_VNIFILTER_ENTRY_GROUP,
++	VXLAN_VNIFILTER_ENTRY_GROUP6,
++	VXLAN_VNIFILTER_ENTRY_STATS,
++	__VXLAN_VNIFILTER_ENTRY_MAX
++};
++#define VXLAN_VNIFILTER_ENTRY_MAX	(__VXLAN_VNIFILTER_ENTRY_MAX - 1)
++
++enum {
++	VXLAN_VNIFILTER_UNSPEC,
++	VXLAN_VNIFILTER_ENTRY,
++	__VXLAN_VNIFILTER_MAX
++};
++#define VXLAN_VNIFILTER_MAX	(__VXLAN_VNIFILTER_MAX - 1)
++
+ enum {
+ 	IFLA_VXLAN_UNSPEC,
+ 	IFLA_VXLAN_ID,
+@@ -741,6 +820,7 @@ enum {
+ 	IFLA_VXLAN_GPE,
+ 	IFLA_VXLAN_TTL_INHERIT,
+ 	IFLA_VXLAN_DF,
++	IFLA_VXLAN_VNIFILTER, /* only applicable with COLLECT_METADATA mode */
+ 	__IFLA_VXLAN_MAX
+ };
+ #define IFLA_VXLAN_MAX	(__IFLA_VXLAN_MAX - 1)
+@@ -774,6 +854,7 @@ enum {
+ 	IFLA_GENEVE_LABEL,
+ 	IFLA_GENEVE_TTL_INHERIT,
+ 	IFLA_GENEVE_DF,
++	IFLA_GENEVE_INNER_PROTO_INHERIT,
+ 	__IFLA_GENEVE_MAX
+ };
+ #define IFLA_GENEVE_MAX	(__IFLA_GENEVE_MAX - 1)
+@@ -819,6 +900,8 @@ enum {
+ 	IFLA_GTP_FD1,
+ 	IFLA_GTP_PDP_HASHSIZE,
+ 	IFLA_GTP_ROLE,
++	IFLA_GTP_CREATE_SOCKETS,
++	IFLA_GTP_RESTART_COUNT,
+ 	__IFLA_GTP_MAX,
+ };
+ #define IFLA_GTP_MAX (__IFLA_GTP_MAX - 1)
+@@ -855,6 +938,9 @@ enum {
+ 	IFLA_BOND_AD_ACTOR_SYSTEM,
+ 	IFLA_BOND_TLB_DYNAMIC_LB,
+ 	IFLA_BOND_PEER_NOTIF_DELAY,
++	IFLA_BOND_AD_LACP_ACTIVE,
++	IFLA_BOND_MISSED_MAX,
++	IFLA_BOND_NS_IP6_TARGET,
+ 	__IFLA_BOND_MAX,
+ };
+ 
+@@ -882,6 +968,7 @@ enum {
+ 	IFLA_BOND_SLAVE_AD_AGGREGATOR_ID,
+ 	IFLA_BOND_SLAVE_AD_ACTOR_OPER_PORT_STATE,
+ 	IFLA_BOND_SLAVE_AD_PARTNER_OPER_PORT_STATE,
++	IFLA_BOND_SLAVE_PRIO,
+ 	__IFLA_BOND_SLAVE_MAX,
+ };
+ 
+@@ -1151,6 +1238,17 @@ enum {
+ 
+ #define IFLA_STATS_FILTER_BIT(ATTR)	(1 << (ATTR - 1))
+ 
++enum {
++	IFLA_STATS_GETSET_UNSPEC,
++	IFLA_STATS_GET_FILTERS, /* Nest of IFLA_STATS_LINK_xxx, each a u32 with
++				 * a filter mask for the corresponding group.
++				 */
++	IFLA_STATS_SET_OFFLOAD_XSTATS_L3_STATS, /* 0 or 1 as u8 */
++	__IFLA_STATS_GETSET_MAX,
++};
++
++#define IFLA_STATS_GETSET_MAX (__IFLA_STATS_GETSET_MAX - 1)
++
+ /* These are embedded into IFLA_STATS_LINK_XSTATS:
+  * [IFLA_STATS_LINK_XSTATS]
+  * -> [LINK_XSTATS_TYPE_xxx]
+@@ -1168,10 +1266,21 @@ enum {
+ enum {
+ 	IFLA_OFFLOAD_XSTATS_UNSPEC,
+ 	IFLA_OFFLOAD_XSTATS_CPU_HIT, /* struct rtnl_link_stats64 */
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO,	/* HW stats info. A nest */
++	IFLA_OFFLOAD_XSTATS_L3_STATS,	/* struct rtnl_hw_stats64 */
+ 	__IFLA_OFFLOAD_XSTATS_MAX
+ };
+ #define IFLA_OFFLOAD_XSTATS_MAX (__IFLA_OFFLOAD_XSTATS_MAX - 1)
+ 
++enum {
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_UNSPEC,
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_REQUEST,		/* u8 */
++	IFLA_OFFLOAD_XSTATS_HW_S_INFO_USED,		/* u8 */
++	__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX,
++};
++#define IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX \
++	(__IFLA_OFFLOAD_XSTATS_HW_S_INFO_MAX - 1)
++
+ /* XDP section */
+ 
+ #define XDP_FLAGS_UPDATE_IF_NOEXIST	(1U << 0)
+@@ -1260,4 +1369,24 @@ struct ifla_rmnet_flags {
+ 	__u32	mask;
+ };
+ 
++/* MCTP section */
++
++enum {
++	IFLA_MCTP_UNSPEC,
++	IFLA_MCTP_NET,
++	__IFLA_MCTP_MAX,
++};
++
++#define IFLA_MCTP_MAX (__IFLA_MCTP_MAX - 1)
++
++/* DSA section */
++
++enum {
++	IFLA_DSA_UNSPEC,
++	IFLA_DSA_MASTER,
++	__IFLA_DSA_MAX,
++};
++
++#define IFLA_DSA_MAX	(__IFLA_DSA_MAX - 1)
++
+ #endif /* _UAPI_LINUX_IF_LINK_H */
+diff --git a/src/basic/linux/if_macsec.h b/src/basic/linux/if_macsec.h
+index 3af2aa069a36..d5b6d1f37353 100644
+--- a/src/basic/linux/if_macsec.h
++++ b/src/basic/linux/if_macsec.h
+@@ -22,6 +22,8 @@
+ 
+ #define MACSEC_KEYID_LEN 16
+ 
++#define MACSEC_SALT_LEN 12
++
+ /* cipher IDs as per IEEE802.1AE-2018 (Table 14-1) */
+ #define MACSEC_CIPHER_ID_GCM_AES_128 0x0080C20001000001ULL
+ #define MACSEC_CIPHER_ID_GCM_AES_256 0x0080C20001000002ULL
+diff --git a/src/basic/linux/if_tun.h b/src/basic/linux/if_tun.h
+index 454ae31b93c7..287cdc81c939 100644
+--- a/src/basic/linux/if_tun.h
++++ b/src/basic/linux/if_tun.h
+@@ -67,6 +67,8 @@
+ #define IFF_TAP		0x0002
+ #define IFF_NAPI	0x0010
+ #define IFF_NAPI_FRAGS	0x0020
++/* Used in TUNSETIFF to bring up tun/tap without carrier */
++#define IFF_NO_CARRIER	0x0040
+ #define IFF_NO_PI	0x1000
+ /* This flag has no real effect */
+ #define IFF_ONE_QUEUE	0x2000
+@@ -88,6 +90,8 @@
+ #define TUN_F_TSO6	0x04	/* I can handle TSO for IPv6 packets */
+ #define TUN_F_TSO_ECN	0x08	/* I can handle TSO with ECN bits. */
+ #define TUN_F_UFO	0x10	/* I can handle UFO packets */
++#define TUN_F_USO4	0x20	/* I can handle USO for IPv4 packets */
++#define TUN_F_USO6	0x40	/* I can handle USO for IPv6 packets */
+ 
+ /* Protocol info prepended to the packets (when IFF_NO_PI is not set) */
+ #define TUN_PKT_STRIP	0x0001
+@@ -108,7 +112,7 @@ struct tun_pi {
+ struct tun_filter {
+ 	__u16  flags; /* TUN_FLT_ flags see above */
+ 	__u16  count; /* Number of addresses */
+-	__u8   addr[0][ETH_ALEN];
++	__u8   addr[][ETH_ALEN];
+ };
+ 
+ #endif /* _UAPI__IF_TUN_H */
+diff --git a/src/basic/linux/if_tunnel.h b/src/basic/linux/if_tunnel.h
+index 7d9105533c7b..102119628ff5 100644
+--- a/src/basic/linux/if_tunnel.h
++++ b/src/basic/linux/if_tunnel.h
+@@ -176,8 +176,10 @@ enum {
+ #define TUNNEL_VXLAN_OPT	__cpu_to_be16(0x1000)
+ #define TUNNEL_NOCACHE		__cpu_to_be16(0x2000)
+ #define TUNNEL_ERSPAN_OPT	__cpu_to_be16(0x4000)
++#define TUNNEL_GTP_OPT		__cpu_to_be16(0x8000)
+ 
+ #define TUNNEL_OPTIONS_PRESENT \
+-		(TUNNEL_GENEVE_OPT | TUNNEL_VXLAN_OPT | TUNNEL_ERSPAN_OPT)
++		(TUNNEL_GENEVE_OPT | TUNNEL_VXLAN_OPT | TUNNEL_ERSPAN_OPT | \
++		TUNNEL_GTP_OPT)
+ 
+ #endif /* _UAPI_IF_TUNNEL_H_ */
+diff --git a/src/basic/linux/in.h b/src/basic/linux/in.h
+index d1b327036ae4..07a4cb149305 100644
+--- a/src/basic/linux/in.h
++++ b/src/basic/linux/in.h
+@@ -20,6 +20,7 @@
+ #define _UAPI_LINUX_IN_H
+ 
+ #include <linux/types.h>
++#include <linux/stddef.h>
+ #include <linux/libc-compat.h>
+ #include <linux/socket.h>
+ 
+@@ -68,6 +69,8 @@ enum {
+ #define IPPROTO_PIM		IPPROTO_PIM
+   IPPROTO_COMP = 108,		/* Compression Header Protocol		*/
+ #define IPPROTO_COMP		IPPROTO_COMP
++  IPPROTO_L2TP = 115,		/* Layer 2 Tunnelling Protocol		*/
++#define IPPROTO_L2TP		IPPROTO_L2TP
+   IPPROTO_SCTP = 132,		/* Stream Control Transport Protocol	*/
+ #define IPPROTO_SCTP		IPPROTO_SCTP
+   IPPROTO_UDPLITE = 136,	/* UDP-Lite (RFC 3828)			*/
+@@ -192,7 +195,10 @@ struct ip_msfilter {
+ 	__be32		imsf_interface;
+ 	__u32		imsf_fmode;
+ 	__u32		imsf_numsrc;
+-	__be32		imsf_slist[1];
++	union {
++		__be32		imsf_slist[1];
++		__DECLARE_FLEX_ARRAY(__be32, imsf_slist_flex);
++	};
+ };
+ 
+ #define IP_MSFILTER_SIZE(numsrc) \
+@@ -211,11 +217,22 @@ struct group_source_req {
+ };
+ 
+ struct group_filter {
+-	__u32				 gf_interface;	/* interface index */
+-	struct __kernel_sockaddr_storage gf_group;	/* multicast address */
+-	__u32				 gf_fmode;	/* filter mode */
+-	__u32				 gf_numsrc;	/* number of sources */
+-	struct __kernel_sockaddr_storage gf_slist[1];	/* interface index */
++	union {
++		struct {
++			__u32				 gf_interface_aux; /* interface index */
++			struct __kernel_sockaddr_storage gf_group_aux;	   /* multicast address */
++			__u32				 gf_fmode_aux;	   /* filter mode */
++			__u32				 gf_numsrc_aux;	   /* number of sources */
++			struct __kernel_sockaddr_storage gf_slist[1];	   /* interface index */
++		};
++		struct {
++			__u32				 gf_interface;	  /* interface index */
++			struct __kernel_sockaddr_storage gf_group;	  /* multicast address */
++			__u32				 gf_fmode;	  /* filter mode */
++			__u32				 gf_numsrc;	  /* number of sources */
++			struct __kernel_sockaddr_storage gf_slist_flex[]; /* interface index */
++		};
++	};
+ };
+ 
+ #define GROUP_FILTER_SIZE(numsrc) \
+diff --git a/src/basic/linux/in6.h b/src/basic/linux/in6.h
+index 5ad396a57eb3..c4c53a9ab959 100644
+--- a/src/basic/linux/in6.h
++++ b/src/basic/linux/in6.h
+@@ -145,6 +145,7 @@ struct in6_flowlabel_req {
+ #define IPV6_TLV_PADN		1
+ #define IPV6_TLV_ROUTERALERT	5
+ #define IPV6_TLV_CALIPSO	7	/* RFC 5570 */
++#define IPV6_TLV_IOAM		49	/* TEMPORARY IANA allocation for IOAM */
+ #define IPV6_TLV_JUMBO		194
+ #define IPV6_TLV_HAO		201	/* home address option */
+ 
+diff --git a/src/basic/linux/l2tp.h b/src/basic/linux/l2tp.h
+index bab8c9708611..7d81c3e1ec29 100644
+--- a/src/basic/linux/l2tp.h
++++ b/src/basic/linux/l2tp.h
+@@ -13,8 +13,6 @@
+ #include <linux/in.h>
+ #include <linux/in6.h>
+ 
+-#define IPPROTO_L2TP		115
+-
+ /**
+  * struct sockaddr_l2tpip - the sockaddr structure for L2TP-over-IP sockets
+  * @l2tp_family:  address family number AF_L2TPIP.
+diff --git a/src/basic/linux/netfilter/nf_tables.h b/src/basic/linux/netfilter/nf_tables.h
+index e94d1fa554cb..cfa844da1ce6 100644
+--- a/src/basic/linux/netfilter/nf_tables.h
++++ b/src/basic/linux/netfilter/nf_tables.h
+@@ -97,6 +97,7 @@ enum nft_verdicts {
+  * @NFT_MSG_NEWFLOWTABLE: add new flow table (enum nft_flowtable_attributes)
+  * @NFT_MSG_GETFLOWTABLE: get flow table (enum nft_flowtable_attributes)
+  * @NFT_MSG_DELFLOWTABLE: delete flow table (enum nft_flowtable_attributes)
++ * @NFT_MSG_GETRULE_RESET: get rules and reset stateful expressions (enum nft_obj_attributes)
+  */
+ enum nf_tables_msg_types {
+ 	NFT_MSG_NEWTABLE,
+@@ -124,6 +125,7 @@ enum nf_tables_msg_types {
+ 	NFT_MSG_NEWFLOWTABLE,
+ 	NFT_MSG_GETFLOWTABLE,
+ 	NFT_MSG_DELFLOWTABLE,
++	NFT_MSG_GETRULE_RESET,
+ 	NFT_MSG_MAX,
+ };
+ 
+@@ -753,11 +755,14 @@ enum nft_dynset_attributes {
+  * @NFT_PAYLOAD_LL_HEADER: link layer header
+  * @NFT_PAYLOAD_NETWORK_HEADER: network header
+  * @NFT_PAYLOAD_TRANSPORT_HEADER: transport header
++ * @NFT_PAYLOAD_INNER_HEADER: inner header / payload
+  */
+ enum nft_payload_bases {
+ 	NFT_PAYLOAD_LL_HEADER,
+ 	NFT_PAYLOAD_NETWORK_HEADER,
+ 	NFT_PAYLOAD_TRANSPORT_HEADER,
++	NFT_PAYLOAD_INNER_HEADER,
++	NFT_PAYLOAD_TUN_HEADER,
+ };
+ 
+ /**
+@@ -777,6 +782,32 @@ enum nft_payload_csum_flags {
+ 	NFT_PAYLOAD_L4CSUM_PSEUDOHDR = (1 << 0),
+ };
+ 
++enum nft_inner_type {
++	NFT_INNER_UNSPEC	= 0,
++	NFT_INNER_VXLAN,
++	NFT_INNER_GENEVE,
++};
++
++enum nft_inner_flags {
++	NFT_INNER_HDRSIZE	= (1 << 0),
++	NFT_INNER_LL		= (1 << 1),
++	NFT_INNER_NH		= (1 << 2),
++	NFT_INNER_TH		= (1 << 3),
++};
++#define NFT_INNER_MASK		(NFT_INNER_HDRSIZE | NFT_INNER_LL | \
++				 NFT_INNER_NH | NFT_INNER_TH)
++
++enum nft_inner_attributes {
++	NFTA_INNER_UNSPEC,
++	NFTA_INNER_NUM,
++	NFTA_INNER_TYPE,
++	NFTA_INNER_FLAGS,
++	NFTA_INNER_HDRSIZE,
++	NFTA_INNER_EXPR,
++	__NFTA_INNER_MAX
++};
++#define NFTA_INNER_MAX	(__NFTA_INNER_MAX - 1)
++
+ /**
+  * enum nft_payload_attributes - nf_tables payload expression netlink attributes
+  *
+@@ -896,7 +927,8 @@ enum nft_meta_keys {
+ 	NFT_META_OIF,
+ 	NFT_META_IIFNAME,
+ 	NFT_META_OIFNAME,
+-	NFT_META_IIFTYPE,
++	NFT_META_IFTYPE,
++#define NFT_META_IIFTYPE	NFT_META_IFTYPE
+ 	NFT_META_OIFTYPE,
+ 	NFT_META_SKUID,
+ 	NFT_META_SKGID,
+@@ -923,6 +955,7 @@ enum nft_meta_keys {
+ 	NFT_META_TIME_HOUR,
+ 	NFT_META_SDIF,
+ 	NFT_META_SDIFNAME,
++	__NFT_META_IIFTYPE,
+ };
+ 
+ /**
+diff --git a/src/basic/linux/netlink.h b/src/basic/linux/netlink.h
+index 4c0cde075c27..e2ae82e3f9f7 100644
+--- a/src/basic/linux/netlink.h
++++ b/src/basic/linux/netlink.h
+@@ -20,7 +20,7 @@
+ #define NETLINK_CONNECTOR	11
+ #define NETLINK_NETFILTER	12	/* netfilter subsystem */
+ #define NETLINK_IP6_FW		13
+-#define NETLINK_DNRTMSG		14	/* DECnet routing messages */
++#define NETLINK_DNRTMSG		14	/* DECnet routing messages (obsolete) */
+ #define NETLINK_KOBJECT_UEVENT	15	/* Kernel messages to userspace */
+ #define NETLINK_GENERIC		16
+ /* leave room for NETLINK_DM (DM Events) */
+@@ -41,12 +41,20 @@ struct sockaddr_nl {
+        	__u32		nl_groups;	/* multicast groups mask */
+ };
+ 
++/**
++ * struct nlmsghdr - fixed format metadata header of Netlink messages
++ * @nlmsg_len:   Length of message including header
++ * @nlmsg_type:  Message content type
++ * @nlmsg_flags: Additional flags
++ * @nlmsg_seq:   Sequence number
++ * @nlmsg_pid:   Sending process port ID
++ */
+ struct nlmsghdr {
+-	__u32		nlmsg_len;	/* Length of message including header */
+-	__u16		nlmsg_type;	/* Message content */
+-	__u16		nlmsg_flags;	/* Additional flags */
+-	__u32		nlmsg_seq;	/* Sequence number */
+-	__u32		nlmsg_pid;	/* Sending process port ID */
++	__u32		nlmsg_len;
++	__u16		nlmsg_type;
++	__u16		nlmsg_flags;
++	__u32		nlmsg_seq;
++	__u32		nlmsg_pid;
+ };
+ 
+ /* Flags values */
+@@ -54,7 +62,7 @@ struct nlmsghdr {
+ #define NLM_F_REQUEST		0x01	/* It is request message. 	*/
+ #define NLM_F_MULTI		0x02	/* Multipart message, terminated by NLMSG_DONE */
+ #define NLM_F_ACK		0x04	/* Reply with ack, with zero or error code */
+-#define NLM_F_ECHO		0x08	/* Echo this request 		*/
++#define NLM_F_ECHO		0x08	/* Receive resulting notifications */
+ #define NLM_F_DUMP_INTR		0x10	/* Dump was inconsistent due to sequence change */
+ #define NLM_F_DUMP_FILTERED	0x20	/* Dump was filtered as requested */
+ 
+@@ -72,6 +80,7 @@ struct nlmsghdr {
+ 
+ /* Modifiers to DELETE request */
+ #define NLM_F_NONREC	0x100	/* Do not delete recursively	*/
++#define NLM_F_BULK	0x200	/* Delete multiple objects	*/
+ 
+ /* Flags for ACK message */
+ #define NLM_F_CAPPED	0x100	/* request was capped */
+@@ -131,6 +140,10 @@ struct nlmsgerr {
+  *	be used - in the success case - to identify a created
+  *	object or operation or similar (binary)
+  * @NLMSGERR_ATTR_POLICY: policy for a rejected attribute
++ * @NLMSGERR_ATTR_MISS_TYPE: type of a missing required attribute,
++ *	%NLMSGERR_ATTR_MISS_NEST will not be present if the attribute was
++ *	missing at the message level
++ * @NLMSGERR_ATTR_MISS_NEST: offset of the nest where attribute was missing
+  * @__NLMSGERR_ATTR_MAX: number of attributes
+  * @NLMSGERR_ATTR_MAX: highest attribute number
+  */
+@@ -140,6 +153,8 @@ enum nlmsgerr_attrs {
+ 	NLMSGERR_ATTR_OFFS,
+ 	NLMSGERR_ATTR_COOKIE,
+ 	NLMSGERR_ATTR_POLICY,
++	NLMSGERR_ATTR_MISS_TYPE,
++	NLMSGERR_ATTR_MISS_NEST,
+ 
+ 	__NLMSGERR_ATTR_MAX,
+ 	NLMSGERR_ATTR_MAX = __NLMSGERR_ATTR_MAX - 1
+@@ -336,6 +351,9 @@ enum netlink_attribute_type {
+  *	bitfield32 type (U32)
+  * @NL_POLICY_TYPE_ATTR_MASK: mask of valid bits for unsigned integers (U64)
+  * @NL_POLICY_TYPE_ATTR_PAD: pad attribute for 64-bit alignment
++ *
++ * @__NL_POLICY_TYPE_ATTR_MAX: number of attributes
++ * @NL_POLICY_TYPE_ATTR_MAX: highest attribute number
+  */
+ enum netlink_policy_type_attr {
+ 	NL_POLICY_TYPE_ATTR_UNSPEC,
+diff --git a/src/basic/linux/nl80211.h b/src/basic/linux/nl80211.h
+index c2efea98e060..c14a91bbca7c 100644
+--- a/src/basic/linux/nl80211.h
++++ b/src/basic/linux/nl80211.h
+@@ -11,7 +11,7 @@
+  * Copyright 2008 Jouni Malinen <jouni.malinen@atheros.com>
+  * Copyright 2008 Colin McCabe <colin@cozybit.com>
+  * Copyright 2015-2017	Intel Deutschland GmbH
+- * Copyright (C) 2018-2021 Intel Corporation
++ * Copyright (C) 2018-2022 Intel Corporation
+  *
+  * Permission to use, copy, modify, and/or distribute this software for any
+  * purpose with or without fee is hereby granted, provided that the above
+@@ -300,6 +300,40 @@
+  * the interface goes down.
+  */
+ 
++/**
++ * DOC: FILS shared key crypto offload
++ *
++ * This feature is applicable to drivers running in AP mode.
++ *
++ * FILS shared key crypto offload can be advertised by drivers by setting
++ * @NL80211_EXT_FEATURE_FILS_CRYPTO_OFFLOAD flag. The drivers that support
++ * FILS shared key crypto offload should be able to encrypt and decrypt
++ * association frames for FILS shared key authentication as per IEEE 802.11ai.
++ * With this capability, for FILS key derivation, drivers depend on userspace.
++ *
++ * After FILS key derivation, userspace shares the FILS AAD details with the
++ * driver and the driver stores the same to use in decryption of association
++ * request and in encryption of association response. The below parameters
++ * should be given to the driver in %NL80211_CMD_SET_FILS_AAD.
++ *	%NL80211_ATTR_MAC - STA MAC address, used for storing FILS AAD per STA
++ *	%NL80211_ATTR_FILS_KEK - Used for encryption or decryption
++ *	%NL80211_ATTR_FILS_NONCES - Used for encryption or decryption
++ *			(STA Nonce 16 bytes followed by AP Nonce 16 bytes)
++ *
++ * Once the association is done, the driver cleans the FILS AAD data.
++ */
++
++/**
++ * DOC: Multi-Link Operation
++ *
++ * In Multi-Link Operation, a connection between to MLDs utilizes multiple
++ * links. To use this in nl80211, various commands and responses now need
++ * to or will include the new %NL80211_ATTR_MLO_LINKS attribute.
++ * Additionally, various commands that need to operate on a specific link
++ * now need to be given the %NL80211_ATTR_MLO_LINK_ID attribute, e.g. to
++ * use %NL80211_CMD_START_AP or similar functions.
++ */
++
+ /**
+  * enum nl80211_commands - supported nl80211 commands
+  *
+@@ -337,17 +371,28 @@
+  * @NL80211_CMD_DEL_INTERFACE: Virtual interface was deleted, has attributes
+  *	%NL80211_ATTR_IFINDEX and %NL80211_ATTR_WIPHY. Can also be sent from
+  *	userspace to request deletion of a virtual interface, then requires
+- *	attribute %NL80211_ATTR_IFINDEX.
++ *	attribute %NL80211_ATTR_IFINDEX. If multiple BSSID advertisements are
++ *	enabled using %NL80211_ATTR_MBSSID_CONFIG, %NL80211_ATTR_MBSSID_ELEMS,
++ *	and if this command is used for the transmitting interface, then all
++ *	the non-transmitting interfaces are deleted as well.
+  *
+  * @NL80211_CMD_GET_KEY: Get sequence counter information for a key specified
+- *	by %NL80211_ATTR_KEY_IDX and/or %NL80211_ATTR_MAC.
++ *	by %NL80211_ATTR_KEY_IDX and/or %NL80211_ATTR_MAC. %NL80211_ATTR_MAC
++ *	represents peer's MLD address for MLO pairwise key. For MLO group key,
++ *	the link is identified by %NL80211_ATTR_MLO_LINK_ID.
+  * @NL80211_CMD_SET_KEY: Set key attributes %NL80211_ATTR_KEY_DEFAULT,
+  *	%NL80211_ATTR_KEY_DEFAULT_MGMT, or %NL80211_ATTR_KEY_THRESHOLD.
++ *	For MLO connection, the link to set default key is identified by
++ *	%NL80211_ATTR_MLO_LINK_ID.
+  * @NL80211_CMD_NEW_KEY: add a key with given %NL80211_ATTR_KEY_DATA,
+  *	%NL80211_ATTR_KEY_IDX, %NL80211_ATTR_MAC, %NL80211_ATTR_KEY_CIPHER,
+- *	and %NL80211_ATTR_KEY_SEQ attributes.
++ *	and %NL80211_ATTR_KEY_SEQ attributes. %NL80211_ATTR_MAC represents
++ *	peer's MLD address for MLO pairwise key. The link to add MLO
++ *	group key is identified by %NL80211_ATTR_MLO_LINK_ID.
+  * @NL80211_CMD_DEL_KEY: delete a key identified by %NL80211_ATTR_KEY_IDX
+- *	or %NL80211_ATTR_MAC.
++ *	or %NL80211_ATTR_MAC. %NL80211_ATTR_MAC represents peer's MLD address
++ *	for MLO pairwise key. The link to delete group key is identified by
++ *	%NL80211_ATTR_MLO_LINK_ID.
+  *
+  * @NL80211_CMD_GET_BEACON: (not used)
+  * @NL80211_CMD_SET_BEACON: change the beacon on an access point interface
+@@ -727,6 +772,13 @@
+  *	%NL80211_ATTR_CSA_C_OFFSETS_TX is an array of offsets to CSA
+  *	counters which will be updated to the current value. This attribute
+  *	is used during CSA period.
++ *	For TX on an MLD, the frequency can be omitted and the link ID be
++ *	specified, or if transmitting to a known peer MLD (with MLD addresses
++ *	in the frame) both can be omitted and the link will be selected by
++ *	lower layers.
++ *	For RX notification, %NL80211_ATTR_RX_HW_TIMESTAMP may be included to
++ *	indicate the frame RX timestamp and %NL80211_ATTR_TX_HW_TIMESTAMP may
++ *	be included to indicate the ack TX timestamp.
+  * @NL80211_CMD_FRAME_WAIT_CANCEL: When an off-channel TX was requested, this
+  *	command may be used with the corresponding cookie to cancel the wait
+  *	time if it is known that it is no longer necessary.  This command is
+@@ -737,7 +789,9 @@
+  *	transmitted with %NL80211_CMD_FRAME. %NL80211_ATTR_COOKIE identifies
+  *	the TX command and %NL80211_ATTR_FRAME includes the contents of the
+  *	frame. %NL80211_ATTR_ACK flag is included if the recipient acknowledged
+- *	the frame.
++ *	the frame. %NL80211_ATTR_TX_HW_TIMESTAMP may be included to indicate the
++ *	tx timestamp and %NL80211_ATTR_RX_HW_TIMESTAMP may be included to
++ *	indicate the ack RX timestamp.
+  * @NL80211_CMD_ACTION_TX_STATUS: Alias for @NL80211_CMD_FRAME_TX_STATUS for
+  *	backward compatibility.
+  *
+@@ -1082,6 +1136,12 @@
+  *	has been received. %NL80211_ATTR_FRAME is used to specify the
+  *	frame contents.  The frame is the raw EAPoL data, without ethernet or
+  *	802.11 headers.
++ *	For an MLD transmitter, the %NL80211_ATTR_MLO_LINK_ID may be given and
++ *	its effect will depend on the destination: If the destination is known
++ *	to be an MLD, this will be used as a hint to select the link to transmit
++ *	the frame on. If the destination is not an MLD, this will select both
++ *	the link to transmit on and the source address will be set to the link
++ *	address of that link.
+  *	When used as an event indication %NL80211_ATTR_CONTROL_PORT_ETHERTYPE,
+  *	%NL80211_ATTR_CONTROL_PORT_NO_ENCRYPT and %NL80211_ATTR_MAC are added
+  *	indicating the protocol type of the received frame; whether the frame
+@@ -1200,6 +1260,27 @@
+  * @NL80211_CMD_COLOR_CHANGE_COMPLETED: Notify userland that the color change
+  *	has completed
+  *
++ * @NL80211_CMD_SET_FILS_AAD: Set FILS AAD data to the driver using -
++ *	&NL80211_ATTR_MAC - for STA MAC address
++ *	&NL80211_ATTR_FILS_KEK - for KEK
++ *	&NL80211_ATTR_FILS_NONCES - for FILS Nonces
++ *		(STA Nonce 16 bytes followed by AP Nonce 16 bytes)
++ *
++ * @NL80211_CMD_ASSOC_COMEBACK: notification about an association
++ *      temporal rejection with comeback. The event includes %NL80211_ATTR_MAC
++ *      to describe the BSSID address of the AP and %NL80211_ATTR_TIMEOUT to
++ *      specify the timeout value.
++ *
++ * @NL80211_CMD_ADD_LINK: Add a new link to an interface. The
++ *	%NL80211_ATTR_MLO_LINK_ID attribute is used for the new link.
++ * @NL80211_CMD_REMOVE_LINK: Remove a link from an interface. This may come
++ *	without %NL80211_ATTR_MLO_LINK_ID as an easy way to remove all links
++ *	in preparation for e.g. roaming to a regular (non-MLO) AP.
++ *
++ * @NL80211_CMD_ADD_LINK_STA: Add a link to an MLD station
++ * @NL80211_CMD_MODIFY_LINK_STA: Modify a link of an MLD station
++ * @NL80211_CMD_REMOVE_LINK_STA: Remove a link of an MLD station
++ *
+  * @NL80211_CMD_MAX: highest used command number
+  * @__NL80211_CMD_AFTER_LAST: internal use
+  */
+@@ -1440,6 +1521,17 @@ enum nl80211_commands {
+ 	NL80211_CMD_COLOR_CHANGE_ABORTED,
+ 	NL80211_CMD_COLOR_CHANGE_COMPLETED,
+ 
++	NL80211_CMD_SET_FILS_AAD,
++
++	NL80211_CMD_ASSOC_COMEBACK,
++
++	NL80211_CMD_ADD_LINK,
++	NL80211_CMD_REMOVE_LINK,
++
++	NL80211_CMD_ADD_LINK_STA,
++	NL80211_CMD_MODIFY_LINK_STA,
++	NL80211_CMD_REMOVE_LINK_STA,
++
+ 	/* add new commands above here */
+ 
+ 	/* used to define NL80211_CMD_MAX below */
+@@ -2299,8 +2391,10 @@ enum nl80211_commands {
+  *
+  * @NL80211_ATTR_IFTYPE_EXT_CAPA: Nested attribute of the following attributes:
+  *	%NL80211_ATTR_IFTYPE, %NL80211_ATTR_EXT_CAPA,
+- *	%NL80211_ATTR_EXT_CAPA_MASK, to specify the extended capabilities per
+- *	interface type.
++ *	%NL80211_ATTR_EXT_CAPA_MASK, to specify the extended capabilities and
++ *	other interface-type specific capabilities per interface type. For MLO,
++ *	%NL80211_ATTR_EML_CAPABILITY and %NL80211_ATTR_MLD_CAPA_AND_OPS are
++ *	present.
+  *
+  * @NL80211_ATTR_MU_MIMO_GROUP_DATA: array of 24 bytes that defines a MU-MIMO
+  *	groupID for monitor mode.
+@@ -2436,7 +2530,9 @@ enum nl80211_commands {
+  *	space supports external authentication. This attribute shall be used
+  *	with %NL80211_CMD_CONNECT and %NL80211_CMD_START_AP request. The driver
+  *	may offload authentication processing to user space if this capability
+- *	is indicated in the respective requests from the user space.
++ *	is indicated in the respective requests from the user space. (This flag
++ *	attribute deprecated for %NL80211_CMD_START_AP, use
++ *	%NL80211_ATTR_AP_SETTINGS_FLAGS)
+  *
+  * @NL80211_ATTR_NSS: Station's New/updated  RX_NSS value notified using this
+  *	u8 attribute. This is used with %NL80211_CMD_STA_OPMODE_CHANGED.
+@@ -2593,6 +2689,68 @@ enum nl80211_commands {
+  * @NL80211_ATTR_COLOR_CHANGE_ELEMS: Nested set of attributes containing the IE
+  *	information for the time while performing a color switch.
+  *
++ * @NL80211_ATTR_MBSSID_CONFIG: Nested attribute for multiple BSSID
++ *	advertisements (MBSSID) parameters in AP mode.
++ *	Kernel uses this attribute to indicate the driver's support for MBSSID
++ *	and enhanced multi-BSSID advertisements (EMA AP) to the userspace.
++ *	Userspace should use this attribute to configure per interface MBSSID
++ *	parameters.
++ *	See &enum nl80211_mbssid_config_attributes for details.
++ *
++ * @NL80211_ATTR_MBSSID_ELEMS: Nested parameter to pass multiple BSSID elements.
++ *	Mandatory parameter for the transmitting interface to enable MBSSID.
++ *	Optional for the non-transmitting interfaces.
++ *
++ * @NL80211_ATTR_RADAR_BACKGROUND: Configure dedicated offchannel chain
++ *	available for radar/CAC detection on some hw. This chain can't be used
++ *	to transmit or receive frames and it is bounded to a running wdev.
++ *	Background radar/CAC detection allows to avoid the CAC downtime
++ *	switching on a different channel during CAC detection on the selected
++ *	radar channel.
++ *
++ * @NL80211_ATTR_AP_SETTINGS_FLAGS: u32 attribute contains ap settings flags,
++ *	enumerated in &enum nl80211_ap_settings_flags. This attribute shall be
++ *	used with %NL80211_CMD_START_AP request.
++ *
++ * @NL80211_ATTR_EHT_CAPABILITY: EHT Capability information element (from
++ *	association request when used with NL80211_CMD_NEW_STATION). Can be set
++ *	only if %NL80211_STA_FLAG_WME is set.
++ *
++ * @NL80211_ATTR_MLO_LINK_ID: A (u8) link ID for use with MLO, to be used with
++ *	various commands that need a link ID to operate.
++ * @NL80211_ATTR_MLO_LINKS: A nested array of links, each containing some
++ *	per-link information and a link ID.
++ * @NL80211_ATTR_MLD_ADDR: An MLD address, used with various commands such as
++ *	authenticate/associate.
++ *
++ * @NL80211_ATTR_MLO_SUPPORT: Flag attribute to indicate user space supports MLO
++ *	connection. Used with %NL80211_CMD_CONNECT. If this attribute is not
++ *	included in NL80211_CMD_CONNECT drivers must not perform MLO connection.
++ *
++ * @NL80211_ATTR_MAX_NUM_AKM_SUITES: U16 attribute. Indicates maximum number of
++ *	AKM suites allowed for %NL80211_CMD_CONNECT, %NL80211_CMD_ASSOCIATE and
++ *	%NL80211_CMD_START_AP in %NL80211_CMD_GET_WIPHY response. If this
++ *	attribute is not present userspace shall consider maximum number of AKM
++ *	suites allowed as %NL80211_MAX_NR_AKM_SUITES which is the legacy maximum
++ *	number prior to the introduction of this attribute.
++ *
++ * @NL80211_ATTR_EML_CAPABILITY: EML Capability information (u16)
++ * @NL80211_ATTR_MLD_CAPA_AND_OPS: MLD Capabilities and Operations (u16)
++ *
++ * @NL80211_ATTR_TX_HW_TIMESTAMP: Hardware timestamp for TX operation in
++ *	nanoseconds (u64). This is the device clock timestamp so it will
++ *	probably reset when the device is stopped or the firmware is reset.
++ *	When used with %NL80211_CMD_FRAME_TX_STATUS, indicates the frame TX
++ *	timestamp. When used with %NL80211_CMD_FRAME RX notification, indicates
++ *	the ack TX timestamp.
++ * @NL80211_ATTR_RX_HW_TIMESTAMP: Hardware timestamp for RX operation in
++ *	nanoseconds (u64). This is the device clock timestamp so it will
++ *	probably reset when the device is stopped or the firmware is reset.
++ *	When used with %NL80211_CMD_FRAME_TX_STATUS, indicates the ack RX
++ *	timestamp. When used with %NL80211_CMD_FRAME RX notification, indicates
++ *	the incoming frame RX timestamp.
++ * @NL80211_ATTR_TD_BITMAP: Transition Disable bitmap, for subsequent
++ *	(re)associations.
+  * @NUM_NL80211_ATTR: total number of nl80211_attrs available
+  * @NL80211_ATTR_MAX: highest attribute number currently defined
+  * @__NL80211_ATTR_AFTER_LAST: internal use
+@@ -3096,6 +3254,32 @@ enum nl80211_attrs {
+ 	NL80211_ATTR_COLOR_CHANGE_COLOR,
+ 	NL80211_ATTR_COLOR_CHANGE_ELEMS,
+ 
++	NL80211_ATTR_MBSSID_CONFIG,
++	NL80211_ATTR_MBSSID_ELEMS,
++
++	NL80211_ATTR_RADAR_BACKGROUND,
++
++	NL80211_ATTR_AP_SETTINGS_FLAGS,
++
++	NL80211_ATTR_EHT_CAPABILITY,
++
++	NL80211_ATTR_DISABLE_EHT,
++
++	NL80211_ATTR_MLO_LINKS,
++	NL80211_ATTR_MLO_LINK_ID,
++	NL80211_ATTR_MLD_ADDR,
++
++	NL80211_ATTR_MLO_SUPPORT,
++
++	NL80211_ATTR_MAX_NUM_AKM_SUITES,
++
++	NL80211_ATTR_EML_CAPABILITY,
++	NL80211_ATTR_MLD_CAPA_AND_OPS,
++
++	NL80211_ATTR_TX_HW_TIMESTAMP,
++	NL80211_ATTR_RX_HW_TIMESTAMP,
++	NL80211_ATTR_TD_BITMAP,
++
+ 	/* add attributes here, update the policy in nl80211.c */
+ 
+ 	__NL80211_ATTR_AFTER_LAST,
+@@ -3150,7 +3334,14 @@ enum nl80211_attrs {
+ #define NL80211_HE_MIN_CAPABILITY_LEN           16
+ #define NL80211_HE_MAX_CAPABILITY_LEN           54
+ #define NL80211_MAX_NR_CIPHER_SUITES		5
++
++/*
++ * NL80211_MAX_NR_AKM_SUITES is obsolete when %NL80211_ATTR_MAX_NUM_AKM_SUITES
++ * present in %NL80211_CMD_GET_WIPHY response.
++ */
+ #define NL80211_MAX_NR_AKM_SUITES		2
++#define NL80211_EHT_MIN_CAPABILITY_LEN          13
++#define NL80211_EHT_MAX_CAPABILITY_LEN          51
+ 
+ #define NL80211_MIN_REMAIN_ON_CHANNEL_TIME	10
+ 
+@@ -3178,7 +3369,7 @@ enum nl80211_attrs {
+  *	and therefore can't be created in the normal ways, use the
+  *	%NL80211_CMD_START_P2P_DEVICE and %NL80211_CMD_STOP_P2P_DEVICE
+  *	commands to create and destroy one
+- * @NL80211_IF_TYPE_OCB: Outside Context of a BSS
++ * @NL80211_IFTYPE_OCB: Outside Context of a BSS
+  *	This mode corresponds to the MIB variable dot11OCBActivated=true
+  * @NL80211_IFTYPE_NAN: NAN device interface type (not a netdev)
+  * @NL80211_IFTYPE_MAX: highest interface type number currently defined
+@@ -3319,6 +3510,56 @@ enum nl80211_he_ru_alloc {
+ 	NL80211_RATE_INFO_HE_RU_ALLOC_2x996,
+ };
+ 
++/**
++ * enum nl80211_eht_gi - EHT guard interval
++ * @NL80211_RATE_INFO_EHT_GI_0_8: 0.8 usec
++ * @NL80211_RATE_INFO_EHT_GI_1_6: 1.6 usec
++ * @NL80211_RATE_INFO_EHT_GI_3_2: 3.2 usec
++ */
++enum nl80211_eht_gi {
++	NL80211_RATE_INFO_EHT_GI_0_8,
++	NL80211_RATE_INFO_EHT_GI_1_6,
++	NL80211_RATE_INFO_EHT_GI_3_2,
++};
++
++/**
++ * enum nl80211_eht_ru_alloc - EHT RU allocation values
++ * @NL80211_RATE_INFO_EHT_RU_ALLOC_26: 26-tone RU allocation
++ * @NL80211_RATE_INFO_EHT_RU_ALLOC_52: 52-tone RU allocation
++ * @NL80211_RATE_INFO_EHT_RU_ALLOC_52P26: 52+26-tone RU allocation
++ * @NL80211_RATE_INFO_EHT_RU_ALLOC_106: 106-tone RU allocation
++ * @NL80211_RATE_INFO_EHT_RU_ALLOC_106P26: 106+26 tone RU allocation
++ * @NL80211_RATE_INFO_EHT_RU_ALLOC_242: 242-tone RU allocation
++ * @NL80211_RATE_INFO_EHT_RU_ALLOC_484: 484-tone RU allocation
++ * @NL80211_RATE_INFO_EHT_RU_ALLOC_484P242: 484+242 tone RU allocation
++ * @NL80211_RATE_INFO_EHT_RU_ALLOC_996: 996-tone RU allocation
++ * @NL80211_RATE_INFO_EHT_RU_ALLOC_996P484: 996+484 tone RU allocation
++ * @NL80211_RATE_INFO_EHT_RU_ALLOC_996P484P242: 996+484+242 tone RU allocation
++ * @NL80211_RATE_INFO_EHT_RU_ALLOC_2x996: 2x996-tone RU allocation
++ * @NL80211_RATE_INFO_EHT_RU_ALLOC_2x996P484: 2x996+484 tone RU allocation
++ * @NL80211_RATE_INFO_EHT_RU_ALLOC_3x996: 3x996-tone RU allocation
++ * @NL80211_RATE_INFO_EHT_RU_ALLOC_3x996P484: 3x996+484 tone RU allocation
++ * @NL80211_RATE_INFO_EHT_RU_ALLOC_4x996: 4x996-tone RU allocation
++ */
++enum nl80211_eht_ru_alloc {
++	NL80211_RATE_INFO_EHT_RU_ALLOC_26,
++	NL80211_RATE_INFO_EHT_RU_ALLOC_52,
++	NL80211_RATE_INFO_EHT_RU_ALLOC_52P26,
++	NL80211_RATE_INFO_EHT_RU_ALLOC_106,
++	NL80211_RATE_INFO_EHT_RU_ALLOC_106P26,
++	NL80211_RATE_INFO_EHT_RU_ALLOC_242,
++	NL80211_RATE_INFO_EHT_RU_ALLOC_484,
++	NL80211_RATE_INFO_EHT_RU_ALLOC_484P242,
++	NL80211_RATE_INFO_EHT_RU_ALLOC_996,
++	NL80211_RATE_INFO_EHT_RU_ALLOC_996P484,
++	NL80211_RATE_INFO_EHT_RU_ALLOC_996P484P242,
++	NL80211_RATE_INFO_EHT_RU_ALLOC_2x996,
++	NL80211_RATE_INFO_EHT_RU_ALLOC_2x996P484,
++	NL80211_RATE_INFO_EHT_RU_ALLOC_3x996,
++	NL80211_RATE_INFO_EHT_RU_ALLOC_3x996P484,
++	NL80211_RATE_INFO_EHT_RU_ALLOC_4x996,
++};
++
+ /**
+  * enum nl80211_rate_info - bitrate information
+  *
+@@ -3358,6 +3599,13 @@ enum nl80211_he_ru_alloc {
+  * @NL80211_RATE_INFO_HE_DCM: HE DCM value (u8, 0/1)
+  * @NL80211_RATE_INFO_RU_ALLOC: HE RU allocation, if not present then
+  *	non-OFDMA was used (u8, see &enum nl80211_he_ru_alloc)
++ * @NL80211_RATE_INFO_320_MHZ_WIDTH: 320 MHz bitrate
++ * @NL80211_RATE_INFO_EHT_MCS: EHT MCS index (u8, 0-15)
++ * @NL80211_RATE_INFO_EHT_NSS: EHT NSS value (u8, 1-8)
++ * @NL80211_RATE_INFO_EHT_GI: EHT guard interval identifier
++ *	(u8, see &enum nl80211_eht_gi)
++ * @NL80211_RATE_INFO_EHT_RU_ALLOC: EHT RU allocation, if not present then
++ *	non-OFDMA was used (u8, see &enum nl80211_eht_ru_alloc)
+  * @__NL80211_RATE_INFO_AFTER_LAST: internal use
+  */
+ enum nl80211_rate_info {
+@@ -3379,6 +3627,11 @@ enum nl80211_rate_info {
+ 	NL80211_RATE_INFO_HE_GI,
+ 	NL80211_RATE_INFO_HE_DCM,
+ 	NL80211_RATE_INFO_HE_RU_ALLOC,
++	NL80211_RATE_INFO_320_MHZ_WIDTH,
++	NL80211_RATE_INFO_EHT_MCS,
++	NL80211_RATE_INFO_EHT_NSS,
++	NL80211_RATE_INFO_EHT_GI,
++	NL80211_RATE_INFO_EHT_RU_ALLOC,
+ 
+ 	/* keep last */
+ 	__NL80211_RATE_INFO_AFTER_LAST,
+@@ -3689,13 +3942,20 @@ enum nl80211_mpath_info {
+  *     capabilities IE
+  * @NL80211_BAND_IFTYPE_ATTR_HE_CAP_PPE: HE PPE thresholds information as
+  *     defined in HE capabilities IE
+- * @NL80211_BAND_IFTYPE_ATTR_MAX: highest band HE capability attribute currently
+- *     defined
+  * @NL80211_BAND_IFTYPE_ATTR_HE_6GHZ_CAPA: HE 6GHz band capabilities (__le16),
+  *	given for all 6 GHz band channels
+  * @NL80211_BAND_IFTYPE_ATTR_VENDOR_ELEMS: vendor element capabilities that are
+  *	advertised on this band/for this iftype (binary)
++ * @NL80211_BAND_IFTYPE_ATTR_EHT_CAP_MAC: EHT MAC capabilities as in EHT
++ *	capabilities element
++ * @NL80211_BAND_IFTYPE_ATTR_EHT_CAP_PHY: EHT PHY capabilities as in EHT
++ *	capabilities element
++ * @NL80211_BAND_IFTYPE_ATTR_EHT_CAP_MCS_SET: EHT supported NSS/MCS as in EHT
++ *	capabilities element
++ * @NL80211_BAND_IFTYPE_ATTR_EHT_CAP_PPE: EHT PPE thresholds information as
++ *	defined in EHT capabilities element
+  * @__NL80211_BAND_IFTYPE_ATTR_AFTER_LAST: internal use
++ * @NL80211_BAND_IFTYPE_ATTR_MAX: highest band attribute currently defined
+  */
+ enum nl80211_band_iftype_attr {
+ 	__NL80211_BAND_IFTYPE_ATTR_INVALID,
+@@ -3707,6 +3967,10 @@ enum nl80211_band_iftype_attr {
+ 	NL80211_BAND_IFTYPE_ATTR_HE_CAP_PPE,
+ 	NL80211_BAND_IFTYPE_ATTR_HE_6GHZ_CAPA,
+ 	NL80211_BAND_IFTYPE_ATTR_VENDOR_ELEMS,
++	NL80211_BAND_IFTYPE_ATTR_EHT_CAP_MAC,
++	NL80211_BAND_IFTYPE_ATTR_EHT_CAP_PHY,
++	NL80211_BAND_IFTYPE_ATTR_EHT_CAP_MCS_SET,
++	NL80211_BAND_IFTYPE_ATTR_EHT_CAP_PPE,
+ 
+ 	/* keep last */
+ 	__NL80211_BAND_IFTYPE_ATTR_AFTER_LAST,
+@@ -3851,6 +4115,10 @@ enum nl80211_wmm_rule {
+  *	on this channel in current regulatory domain.
+  * @NL80211_FREQUENCY_ATTR_16MHZ: 16 MHz operation is allowed
+  *	on this channel in current regulatory domain.
++ * @NL80211_FREQUENCY_ATTR_NO_320MHZ: any 320 MHz channel using this channel
++ *	as the primary or any of the secondary channels isn't possible
++ * @NL80211_FREQUENCY_ATTR_NO_EHT: EHT operation is not allowed on this channel
++ *	in current regulatory domain.
+  * @NL80211_FREQUENCY_ATTR_MAX: highest frequency attribute number
+  *	currently defined
+  * @__NL80211_FREQUENCY_ATTR_AFTER_LAST: internal use
+@@ -3887,6 +4155,8 @@ enum nl80211_frequency_attr {
+ 	NL80211_FREQUENCY_ATTR_4MHZ,
+ 	NL80211_FREQUENCY_ATTR_8MHZ,
+ 	NL80211_FREQUENCY_ATTR_16MHZ,
++	NL80211_FREQUENCY_ATTR_NO_320MHZ,
++	NL80211_FREQUENCY_ATTR_NO_EHT,
+ 
+ 	/* keep last */
+ 	__NL80211_FREQUENCY_ATTR_AFTER_LAST,
+@@ -4085,6 +4355,7 @@ enum nl80211_sched_scan_match_attr {
+  * @NL80211_RRF_NO_80MHZ: 80MHz operation not allowed
+  * @NL80211_RRF_NO_160MHZ: 160MHz operation not allowed
+  * @NL80211_RRF_NO_HE: HE operation not allowed
++ * @NL80211_RRF_NO_320MHZ: 320MHz operation not allowed
+  */
+ enum nl80211_reg_rule_flags {
+ 	NL80211_RRF_NO_OFDM		= 1<<0,
+@@ -4103,6 +4374,7 @@ enum nl80211_reg_rule_flags {
+ 	NL80211_RRF_NO_80MHZ		= 1<<15,
+ 	NL80211_RRF_NO_160MHZ		= 1<<16,
+ 	NL80211_RRF_NO_HE		= 1<<17,
++	NL80211_RRF_NO_320MHZ		= 1<<18,
+ };
+ 
+ #define NL80211_RRF_PASSIVE_SCAN	NL80211_RRF_NO_IR
+@@ -4600,6 +4872,8 @@ enum nl80211_key_mode {
+  * @NL80211_CHAN_WIDTH_4: 4 MHz OFDM channel
+  * @NL80211_CHAN_WIDTH_8: 8 MHz OFDM channel
+  * @NL80211_CHAN_WIDTH_16: 16 MHz OFDM channel
++ * @NL80211_CHAN_WIDTH_320: 320 MHz channel, the %NL80211_ATTR_CENTER_FREQ1
++ *	attribute must be provided as well
+  */
+ enum nl80211_chan_width {
+ 	NL80211_CHAN_WIDTH_20_NOHT,
+@@ -4615,6 +4889,7 @@ enum nl80211_chan_width {
+ 	NL80211_CHAN_WIDTH_4,
+ 	NL80211_CHAN_WIDTH_8,
+ 	NL80211_CHAN_WIDTH_16,
++	NL80211_CHAN_WIDTH_320,
+ };
+ 
+ /**
+@@ -4686,6 +4961,8 @@ enum nl80211_bss_scan_width {
+  *	Contains a nested array of signal strength attributes (u8, dBm),
+  *	using the nesting index as the antenna number.
+  * @NL80211_BSS_FREQUENCY_OFFSET: frequency offset in KHz
++ * @NL80211_BSS_MLO_LINK_ID: MLO link ID of the BSS (u8).
++ * @NL80211_BSS_MLD_ADDR: MLD address of this BSS if connected to it.
+  * @__NL80211_BSS_AFTER_LAST: internal
+  * @NL80211_BSS_MAX: highest BSS attribute
+  */
+@@ -4711,6 +4988,8 @@ enum nl80211_bss {
+ 	NL80211_BSS_PARENT_BSSID,
+ 	NL80211_BSS_CHAIN_SIGNAL,
+ 	NL80211_BSS_FREQUENCY_OFFSET,
++	NL80211_BSS_MLO_LINK_ID,
++	NL80211_BSS_MLD_ADDR,
+ 
+ 	/* keep last */
+ 	__NL80211_BSS_AFTER_LAST,
+@@ -4929,6 +5208,7 @@ enum nl80211_txrate_gi {
+  * @NL80211_BAND_60GHZ: around 60 GHz band (58.32 - 69.12 GHz)
+  * @NL80211_BAND_6GHZ: around 6 GHz band (5.9 - 7.2 GHz)
+  * @NL80211_BAND_S1GHZ: around 900MHz, supported by S1G PHYs
++ * @NL80211_BAND_LC: light communication band (placeholder)
+  * @NUM_NL80211_BANDS: number of bands, avoid using this in userspace
+  *	since newer kernel versions may support more bands
+  */
+@@ -4938,6 +5218,7 @@ enum nl80211_band {
+ 	NL80211_BAND_60GHZ,
+ 	NL80211_BAND_6GHZ,
+ 	NL80211_BAND_S1GHZ,
++	NL80211_BAND_LC,
+ 
+ 	NUM_NL80211_BANDS,
+ };
+@@ -5504,7 +5785,7 @@ enum nl80211_iface_limit_attrs {
+  *	=> allows 8 of AP/GO that can have BI gcd >= min gcd
+  *
+  *	numbers = [ #{STA} <= 2 ], channels = 2, max = 2
+- *	=> allows two STAs on different channels
++ *	=> allows two STAs on the same or on different channels
+  *
+  *	numbers = [ #{STA} <= 1, #{P2P-client,P2P-GO} <= 3 ], max = 4
+  *	=> allows a STA plus three P2P interfaces
+@@ -5549,7 +5830,7 @@ enum nl80211_if_combination_attrs {
+  * @NL80211_PLINK_ESTAB: mesh peer link is established
+  * @NL80211_PLINK_HOLDING: mesh peer link is being closed or cancelled
+  * @NL80211_PLINK_BLOCKED: all frames transmitted from this mesh
+- *	plink are discarded
++ *	plink are discarded, except for authentication frames
+  * @NUM_NL80211_PLINK_STATES: number of peer link states
+  * @MAX_NL80211_PLINK_STATES: highest numerical value of plink states
+  */
+@@ -5686,13 +5967,15 @@ enum nl80211_tdls_operation {
+ 	NL80211_TDLS_DISABLE_LINK,
+ };
+ 
+-/*
++/**
+  * enum nl80211_ap_sme_features - device-integrated AP features
+- * Reserved for future use, no bits are defined in
+- * NL80211_ATTR_DEVICE_AP_SME yet.
++ * @NL80211_AP_SME_SA_QUERY_OFFLOAD: SA Query procedures offloaded to driver
++ *	when user space indicates support for SA Query procedures offload during
++ *	"start ap" with %NL80211_AP_SETTINGS_SA_QUERY_OFFLOAD_SUPPORT.
++ */
+ enum nl80211_ap_sme_features {
++	NL80211_AP_SME_SA_QUERY_OFFLOAD		= 1 << 0,
+ };
+- */
+ 
+ /**
+  * enum nl80211_feature_flags - device/driver features
+@@ -5703,7 +5986,7 @@ enum nl80211_ap_sme_features {
+  * @NL80211_FEATURE_INACTIVITY_TIMER: This driver takes care of freeing up
+  *	the connected inactive stations in AP mode.
+  * @NL80211_FEATURE_CELL_BASE_REG_HINTS: This driver has been tested
+- *	to work properly to suppport receiving regulatory hints from
++ *	to work properly to support receiving regulatory hints from
+  *	cellular base stations.
+  * @NL80211_FEATURE_P2P_DEVICE_NEEDS_CHANNEL: (no longer available, only
+  *	here to reserve the value for API/ABI compatibility)
+@@ -5995,6 +6278,22 @@ enum nl80211_feature_flags {
+  * @NL80211_EXT_FEATURE_BSS_COLOR: The driver supports BSS color collision
+  *	detection and change announcemnts.
+  *
++ * @NL80211_EXT_FEATURE_FILS_CRYPTO_OFFLOAD: Driver running in AP mode supports
++ *	FILS encryption and decryption for (Re)Association Request and Response
++ *	frames. Userspace has to share FILS AAD details to the driver by using
++ *	@NL80211_CMD_SET_FILS_AAD.
++ *
++ * @NL80211_EXT_FEATURE_RADAR_BACKGROUND: Device supports background radar/CAC
++ *	detection.
++ *
++ * @NL80211_EXT_FEATURE_POWERED_ADDR_CHANGE: Device can perform a MAC address
++ *	change without having to bring the underlying network device down
++ *	first. For example, in station mode this can be used to vary the
++ *	origin MAC address prior to a connection to a new AP for privacy
++ *	or other reasons. Note that certain driver specific restrictions
++ *	might apply, e.g. no scans in progress, no offchannel operations
++ *	in progress, and no active connections.
++ *
+  * @NUM_NL80211_EXT_FEATURES: number of extended features.
+  * @MAX_NL80211_EXT_FEATURES: highest extended feature index.
+  */
+@@ -6060,6 +6359,9 @@ enum nl80211_ext_feature_index {
+ 	NL80211_EXT_FEATURE_SECURE_RTT,
+ 	NL80211_EXT_FEATURE_PROT_RANGE_NEGO_AND_MEASURE,
+ 	NL80211_EXT_FEATURE_BSS_COLOR,
++	NL80211_EXT_FEATURE_FILS_CRYPTO_OFFLOAD,
++	NL80211_EXT_FEATURE_RADAR_BACKGROUND,
++	NL80211_EXT_FEATURE_POWERED_ADDR_CHANGE,
+ 
+ 	/* add new features before the definition below */
+ 	NUM_NL80211_EXT_FEATURES,
+@@ -7349,4 +7651,76 @@ enum nl80211_sar_specs_attrs {
+ 	NL80211_SAR_ATTR_SPECS_MAX = __NL80211_SAR_ATTR_SPECS_LAST - 1,
+ };
+ 
++/**
++ * enum nl80211_mbssid_config_attributes - multiple BSSID (MBSSID) and enhanced
++ * multi-BSSID advertisements (EMA) in AP mode.
++ * Kernel uses some of these attributes to advertise driver's support for
++ * MBSSID and EMA.
++ * Remaining attributes should be used by the userspace to configure the
++ * features.
++ *
++ * @__NL80211_MBSSID_CONFIG_ATTR_INVALID: Invalid
++ *
++ * @NL80211_MBSSID_CONFIG_ATTR_MAX_INTERFACES: Used by the kernel to advertise
++ *	the maximum number of MBSSID interfaces supported by the driver.
++ *	Driver should indicate MBSSID support by setting
++ *	wiphy->mbssid_max_interfaces to a value more than or equal to 2.
++ *
++ * @NL80211_MBSSID_CONFIG_ATTR_MAX_EMA_PROFILE_PERIODICITY: Used by the kernel
++ *	to advertise the maximum profile periodicity supported by the driver
++ *	if EMA is enabled. Driver should indicate EMA support to the userspace
++ *	by setting wiphy->ema_max_profile_periodicity to
++ *	a non-zero value.
++ *
++ * @NL80211_MBSSID_CONFIG_ATTR_INDEX: Mandatory parameter to pass the index of
++ *	this BSS (u8) in the multiple BSSID set.
++ *	Value must be set to 0 for the transmitting interface and non-zero for
++ *	all non-transmitting interfaces. The userspace will be responsible
++ *	for using unique indices for the interfaces.
++ *	Range: 0 to wiphy->mbssid_max_interfaces-1.
++ *
++ * @NL80211_MBSSID_CONFIG_ATTR_TX_IFINDEX: Mandatory parameter for
++ *	a non-transmitted profile which provides the interface index (u32) of
++ *	the transmitted profile. The value must match one of the interface
++ *	indices advertised by the kernel. Optional if the interface being set up
++ *	is the transmitting one, however, if provided then the value must match
++ *	the interface index of the same.
++ *
++ * @NL80211_MBSSID_CONFIG_ATTR_EMA: Flag used to enable EMA AP feature.
++ *	Setting this flag is permitted only if the driver advertises EMA support
++ *	by setting wiphy->ema_max_profile_periodicity to non-zero.
++ *
++ * @__NL80211_MBSSID_CONFIG_ATTR_LAST: Internal
++ * @NL80211_MBSSID_CONFIG_ATTR_MAX: highest attribute
++ */
++enum nl80211_mbssid_config_attributes {
++	__NL80211_MBSSID_CONFIG_ATTR_INVALID,
++
++	NL80211_MBSSID_CONFIG_ATTR_MAX_INTERFACES,
++	NL80211_MBSSID_CONFIG_ATTR_MAX_EMA_PROFILE_PERIODICITY,
++	NL80211_MBSSID_CONFIG_ATTR_INDEX,
++	NL80211_MBSSID_CONFIG_ATTR_TX_IFINDEX,
++	NL80211_MBSSID_CONFIG_ATTR_EMA,
++
++	/* keep last */
++	__NL80211_MBSSID_CONFIG_ATTR_LAST,
++	NL80211_MBSSID_CONFIG_ATTR_MAX = __NL80211_MBSSID_CONFIG_ATTR_LAST - 1,
++};
++
++/**
++ * enum nl80211_ap_settings_flags - AP settings flags
++ *
++ * @NL80211_AP_SETTINGS_EXTERNAL_AUTH_SUPPORT: AP supports external
++ *	authentication.
++ * @NL80211_AP_SETTINGS_SA_QUERY_OFFLOAD_SUPPORT: Userspace supports SA Query
++ *	procedures offload to driver. If driver advertises
++ *	%NL80211_AP_SME_SA_QUERY_OFFLOAD in AP SME features, userspace shall
++ *	ignore SA Query procedures and validations when this flag is set by
++ *	userspace.
++ */
++enum nl80211_ap_settings_flags {
++	NL80211_AP_SETTINGS_EXTERNAL_AUTH_SUPPORT	= 1 << 0,
++	NL80211_AP_SETTINGS_SA_QUERY_OFFLOAD_SUPPORT	= 1 << 1,
++};
++
+ #endif /* __LINUX_NL80211_H */
+diff --git a/src/basic/linux/pkt_sched.h b/src/basic/linux/pkt_sched.h
+index 79a699f106b1..000eec106856 100644
+--- a/src/basic/linux/pkt_sched.h
++++ b/src/basic/linux/pkt_sched.h
+@@ -827,6 +827,8 @@ struct tc_codel_xstats {
+ 
+ /* FQ_CODEL */
+ 
++#define FQ_CODEL_QUANTUM_MAX (1 << 20)
++
+ enum {
+ 	TCA_FQ_CODEL_UNSPEC,
+ 	TCA_FQ_CODEL_TARGET,
+@@ -838,6 +840,8 @@ enum {
+ 	TCA_FQ_CODEL_CE_THRESHOLD,
+ 	TCA_FQ_CODEL_DROP_BATCH_SIZE,
+ 	TCA_FQ_CODEL_MEMORY_LIMIT,
++	TCA_FQ_CODEL_CE_THRESHOLD_SELECTOR,
++	TCA_FQ_CODEL_CE_THRESHOLD_MASK,
+ 	__TCA_FQ_CODEL_MAX
+ };
+ 
+@@ -1228,6 +1232,16 @@ enum {
+ #define TCA_TAPRIO_ATTR_FLAG_TXTIME_ASSIST	_BITUL(0)
+ #define TCA_TAPRIO_ATTR_FLAG_FULL_OFFLOAD	_BITUL(1)
+ 
++enum {
++	TCA_TAPRIO_TC_ENTRY_UNSPEC,
++	TCA_TAPRIO_TC_ENTRY_INDEX,		/* u32 */
++	TCA_TAPRIO_TC_ENTRY_MAX_SDU,		/* u32 */
++
++	/* add new constants above here */
++	__TCA_TAPRIO_TC_ENTRY_CNT,
++	TCA_TAPRIO_TC_ENTRY_MAX = (__TCA_TAPRIO_TC_ENTRY_CNT - 1)
++};
++
+ enum {
+ 	TCA_TAPRIO_ATTR_UNSPEC,
+ 	TCA_TAPRIO_ATTR_PRIOMAP, /* struct tc_mqprio_qopt */
+@@ -1241,6 +1255,7 @@ enum {
+ 	TCA_TAPRIO_ATTR_SCHED_CYCLE_TIME_EXTENSION, /* s64 */
+ 	TCA_TAPRIO_ATTR_FLAGS, /* u32 */
+ 	TCA_TAPRIO_ATTR_TXTIME_DELAY, /* u32 */
++	TCA_TAPRIO_ATTR_TC_ENTRY, /* nest */
+ 	__TCA_TAPRIO_ATTR_MAX,
+ };
+ 
+diff --git a/src/basic/linux/rtnetlink.h b/src/basic/linux/rtnetlink.h
+index 5888492a5257..eb2747d58a81 100644
+--- a/src/basic/linux/rtnetlink.h
++++ b/src/basic/linux/rtnetlink.h
+@@ -146,6 +146,8 @@ enum {
+ #define RTM_NEWSTATS RTM_NEWSTATS
+ 	RTM_GETSTATS = 94,
+ #define RTM_GETSTATS RTM_GETSTATS
++	RTM_SETSTATS,
++#define RTM_SETSTATS RTM_SETSTATS
+ 
+ 	RTM_NEWCACHEREPORT = 96,
+ #define RTM_NEWCACHEREPORT RTM_NEWCACHEREPORT
+@@ -185,6 +187,13 @@ enum {
+ 	RTM_GETNEXTHOPBUCKET,
+ #define RTM_GETNEXTHOPBUCKET	RTM_GETNEXTHOPBUCKET
+ 
++	RTM_NEWTUNNEL = 120,
++#define RTM_NEWTUNNEL	RTM_NEWTUNNEL
++	RTM_DELTUNNEL,
++#define RTM_DELTUNNEL	RTM_DELTUNNEL
++	RTM_GETTUNNEL,
++#define RTM_GETTUNNEL	RTM_GETTUNNEL
++
+ 	__RTM_MAX,
+ #define RTM_MAX		(((__RTM_MAX + 3) & ~3) - 1)
+ };
+@@ -431,7 +440,7 @@ struct rtnexthop {
+ /* RTA_VIA */
+ struct rtvia {
+ 	__kernel_sa_family_t	rtvia_family;
+-	__u8			rtvia_addr[0];
++	__u8			rtvia_addr[];
+ };
+ 
+ /* RTM_CACHEINFO */
+@@ -754,6 +763,12 @@ enum rtnetlink_groups {
+ #define RTNLGRP_NEXTHOP		RTNLGRP_NEXTHOP
+ 	RTNLGRP_BRVLAN,
+ #define RTNLGRP_BRVLAN		RTNLGRP_BRVLAN
++	RTNLGRP_MCTP_IFADDR,
++#define RTNLGRP_MCTP_IFADDR	RTNLGRP_MCTP_IFADDR
++	RTNLGRP_TUNNEL,
++#define RTNLGRP_TUNNEL		RTNLGRP_TUNNEL
++	RTNLGRP_STATS,
++#define RTNLGRP_STATS		RTNLGRP_STATS
+ 	__RTNLGRP_MAX
+ };
+ #define RTNLGRP_MAX	(__RTNLGRP_MAX - 1)
+@@ -802,6 +817,7 @@ enum {
+ #define RTEXT_FILTER_MRP	(1 << 4)
+ #define RTEXT_FILTER_CFM_CONFIG	(1 << 5)
+ #define RTEXT_FILTER_CFM_STATUS	(1 << 6)
++#define RTEXT_FILTER_MST	(1 << 7)
+ 
+ /* End of information exported to user level */
+ 
+diff --git a/src/basic/linux/stddef.h b/src/basic/linux/stddef.h
+new file mode 100644
+index 000000000000..1a739631b91c
+--- /dev/null
++++ b/src/basic/linux/stddef.h
+@@ -0,0 +1,46 @@
++/* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
++#ifndef _UAPI_LINUX_STDDEF_H
++#define _UAPI_LINUX_STDDEF_H
++
++
++#ifndef __always_inline
++#define __always_inline inline
++#endif
++
++/**
++ * __struct_group() - Create a mirrored named and anonyomous struct
++ *
++ * @TAG: The tag name for the named sub-struct (usually empty)
++ * @NAME: The identifier name of the mirrored sub-struct
++ * @ATTRS: Any struct attributes (usually empty)
++ * @MEMBERS: The member declarations for the mirrored structs
++ *
++ * Used to create an anonymous union of two structs with identical layout
++ * and size: one anonymous and one named. The former's members can be used
++ * normally without sub-struct naming, and the latter can be used to
++ * reason about the start, end, and size of the group of struct members.
++ * The named struct can also be explicitly tagged for layer reuse, as well
++ * as both having struct attributes appended.
++ */
++#define __struct_group(TAG, NAME, ATTRS, MEMBERS...) \
++	union { \
++		struct { MEMBERS } ATTRS; \
++		struct TAG { MEMBERS } ATTRS NAME; \
++	}
++
++/**
++ * __DECLARE_FLEX_ARRAY() - Declare a flexible array usable in a union
++ *
++ * @TYPE: The type of each flexible array element
++ * @NAME: The name of the flexible array member
++ *
++ * In order to have a flexible array member in a union or alone in a
++ * struct, it needs to be wrapped in an anonymous struct with at least 1
++ * named member, but that member can be empty.
++ */
++#define __DECLARE_FLEX_ARRAY(TYPE, NAME)	\
++	struct { \
++		struct { } __empty_ ## NAME; \
++		TYPE NAME[]; \
++	}
++#endif
+diff --git a/src/basic/linux/update.sh b/src/basic/linux/update.sh
+index 72e133d0bcd7..6aff039d3ef5 100755
+--- a/src/basic/linux/update.sh
++++ b/src/basic/linux/update.sh
+@@ -6,5 +6,5 @@ set -o pipefail
+ for i in *.h */*.h; do
+     curl --fail "https://raw.githubusercontent.com/torvalds/linux/master/include/uapi/linux/$i" -o "$i"
+ 
+-    sed -i -e 's/__user //g' -e '/^#include <linux\/compiler.h>/ d' "$i"
++    sed -r -i -e 's/__user //g' -e '/^#include <linux\/compiler(_types)?.h>/ d' "$i"
+ done
+-- 
+2.46.1
+

--- a/recipes-core/systemd/files/0001-network-bridge-add-support-for-NO_LL_LEARN.patch
+++ b/recipes-core/systemd/files/0001-network-bridge-add-support-for-NO_LL_LEARN.patch
@@ -1,0 +1,84 @@
+From d1692fb33ceb8d89688e98f29fcb78010d6b93ec Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Wed, 11 Dec 2024 09:24:54 +0100
+Subject: [PATCH 1/3] network: bridge: add support for NO_LL_LEARN
+
+When using locked ports on a bridge link-local learning needs to be
+disabled to prevent the kernel from learning and automatically unlocking
+hosts based on link-local traffic.
+
+So add support for enabling NO_LL_LEARN for bridges.
+
+Upstream-Status: Backport [https://github.com/systemd/systemd/commit/d7de242ce78ae2782ac483da76204d305ff49ac7]
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ src/network/netdev/bridge.c           | 13 +++++++++++++
+ src/network/netdev/bridge.h           |  1 +
+ src/network/netdev/netdev-gperf.gperf |  1 +
+ 3 files changed, 15 insertions(+)
+
+diff --git a/src/network/netdev/bridge.c b/src/network/netdev/bridge.c
+index b974f2ae0a67..3e5e474a5513 100644
+--- a/src/network/netdev/bridge.c
++++ b/src/network/netdev/bridge.c
+@@ -48,6 +48,7 @@ static int netdev_bridge_set_handler(sd_netlink *rtnl, sd_netlink_message *m, Ne
+ static int netdev_bridge_post_create(NetDev *netdev, Link *link, sd_netlink_message *m) {
+         _cleanup_(sd_netlink_message_unrefp) sd_netlink_message *req = NULL;
+         Bridge *b;
++        struct br_boolopt_multi bm = {};
+         int r;
+ 
+         assert(netdev);
+@@ -151,6 +152,17 @@ static int netdev_bridge_post_create(NetDev *netdev, Link *link, sd_netlink_mess
+                         return log_netdev_error_errno(netdev, r, "Could not append IFLA_BR_MCAST_IGMP_VERSION attribute: %m");
+         }
+ 
++        if (b->linklocal_learn >= 0) {
++                bm.optmask |= 1 << BR_BOOLOPT_NO_LL_LEARN;
++		SET_FLAG(bm.optval, 1 << BR_BOOLOPT_NO_LL_LEARN, !b->linklocal_learn);
++        }
++
++        if (bm.optmask != 0) {
++                r = sd_netlink_message_append_data(req, IFLA_BR_MULTI_BOOLOPT, &bm, sizeof(bm));
++                if (r < 0)
++                        return r;
++        }
++
+         r = sd_netlink_message_close_container(req);
+         if (r < 0)
+                 return log_netdev_error_errno(netdev, r, "Could not append IFLA_LINKINFO attribute: %m");
+@@ -269,6 +281,7 @@ static void bridge_init(NetDev *n) {
+         b->default_pvid = VLANID_INVALID;
+         b->forward_delay = USEC_INFINITY;
+         b->ageing_time = USEC_INFINITY;
++        b->linklocal_learn = -1;
+ }
+ 
+ const NetDevVTable bridge_vtable = {
+diff --git a/src/network/netdev/bridge.h b/src/network/netdev/bridge.h
+index a6f322404410..e27178afe9c9 100644
+--- a/src/network/netdev/bridge.h
++++ b/src/network/netdev/bridge.h
+@@ -19,6 +19,7 @@ typedef struct Bridge {
+         uint16_t group_fwd_mask;
+         uint16_t default_pvid;
+         uint8_t igmp_version;
++        int linklocal_learn;
+ 
+         usec_t forward_delay;
+         usec_t hello_time;
+diff --git a/src/network/netdev/netdev-gperf.gperf b/src/network/netdev/netdev-gperf.gperf
+index a948ec2c8a0e..5627814d0940 100644
+--- a/src/network/netdev/netdev-gperf.gperf
++++ b/src/network/netdev/netdev-gperf.gperf
+@@ -221,6 +221,7 @@ Bridge.VLANFiltering,                     config_parse_tristate,
+ Bridge.VLANProtocol,                      config_parse_vlanprotocol,                 0,                             offsetof(Bridge, vlan_protocol)
+ Bridge.STP,                               config_parse_tristate,                     0,                             offsetof(Bridge, stp)
+ Bridge.MulticastIGMPVersion,              config_parse_uint8,                        0,                             offsetof(Bridge, igmp_version)
++Bridge.LinkLocalLearning,                 config_parse_tristate,                     0,                             offsetof(Bridge, linklocal_learn)
+ VRF.TableId,                              config_parse_uint32,                       0,                             offsetof(Vrf, table) /* deprecated */
+ VRF.Table,                                config_parse_uint32,                       0,                             offsetof(Vrf, table)
+ BareUDP.DestinationPort,                  config_parse_ip_port,                      0,                             offsetof(BareUDP, dest_port)
+-- 
+2.47.1
+

--- a/recipes-core/systemd/files/0001-partition-fix-build-with-newer-linux-btrfs.h-uapi-he.patch
+++ b/recipes-core/systemd/files/0001-partition-fix-build-with-newer-linux-btrfs.h-uapi-he.patch
@@ -1,0 +1,56 @@
+From 077aeaf270aceb1841ea1e80809f097d72a036d2 Mon Sep 17 00:00:00 2001
+From: Frantisek Sumsal <frantisek@sumsal.cz>
+Date: Wed, 25 Jan 2023 13:21:09 +0100
+Subject: [PATCH] partition: fix build with newer linux/btrfs.h uapi header
+
+linux/btrfs.h needs  to be included after sys/mount.h, as since [0]
+linux/btrfs.h includes linux/fs.h causing build errors:
+
+```
+In file included from /usr/include/linux/fs.h:19,
+                 from ../src/basic/linux/btrfs.h:29,
+                 from ../src/partition/growfs.c:6:
+/usr/include/sys/mount.h:35:3: error: expected identifier before numeric constant
+   35 |   MS_RDONLY = 1,                /* Mount read-only.  */
+      |   ^~~~~~~~~
+[1222/2169] Compiling C object systemd-creds.p/src_creds_creds.c.o
+ninja: build stopped: subcommand failed.
+```
+
+See: https://github.com/systemd/systemd/issues/8507
+
+[0] https://github.com/torvalds/linux/commit/a28135303a669917002f569aecebd5758263e4aa
+
+(cherry picked from commit ed614f17fc9f3876b2178db949df42a2605f6895)
+(cherry picked from commit 8f84df0da357128f1275933cd8aab4c5efad5767)
+(cherry picked from commit 1fc632e15162e0cd02cadc2b8f7fcf1d3b718cbb)
+---
+ src/partition/growfs.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/src/partition/growfs.c b/src/partition/growfs.c
+index ced54f141342..c08c26d92931 100644
+--- a/src/partition/growfs.c
++++ b/src/partition/growfs.c
+@@ -3,12 +3,17 @@
+ #include <errno.h>
+ #include <fcntl.h>
+ #include <getopt.h>
+-#include <linux/btrfs.h>
+ #include <linux/magic.h>
+ #include <sys/ioctl.h>
+ #include <sys/mount.h>
+ #include <sys/types.h>
+ #include <sys/vfs.h>
++/* This needs to be included after sys/mount.h, as since [0] linux/btrfs.h
++ * includes linux/fs.h causing build errors
++ * See: https://github.com/systemd/systemd/issues/8507
++ * [0] https://github.com/torvalds/linux/commit/a28135303a669917002f569aecebd5758263e4aa
++ */
++#include <linux/btrfs.h>
+ 
+ #include "blockdev-util.h"
+ #include "btrfs-util.h"
+-- 
+2.46.1
+

--- a/recipes-core/systemd/files/0002-network-bridge-add-support-for-IFLA_BRPORT_LOCKED.patch
+++ b/recipes-core/systemd/files/0002-network-bridge-add-support-for-IFLA_BRPORT_LOCKED.patch
@@ -1,0 +1,93 @@
+From eefad83d9db92603b01238c3e2e2cd919798e824 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Mon, 2 Dec 2024 12:48:22 +0100
+Subject: [PATCH 2/3] network: bridge: add support for IFLA_BRPORT_LOCKED
+
+Since linux commit a21d9a670d81 ("net: bridge: Add support for bridge
+port in locked mode") it is possible to set bridge ports to locked.
+
+Locked ports do not learn automatically, and discard any traffic from
+unknown source MACs. To allow traffic, the userspace authenticator is
+expected to create fdb entries for authenticated hosts.
+
+Add support to systemd-network for setting the new attribute for bridge
+ports.
+
+Upstream-Status: Backport [https://github.com/systemd/systemd/commit/a434de60568b0f34c07de4f97af6cdc33d4fd2a2]
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ src/libsystemd/sd-netlink/netlink-types-rtnl.c | 1 +
+ src/network/networkd-network-gperf.gperf       | 1 +
+ src/network/networkd-network.c                 | 1 +
+ src/network/networkd-network.h                 | 1 +
+ src/network/networkd-setlink.c                 | 6 ++++++
+ 5 files changed, 10 insertions(+)
+
+diff --git a/src/libsystemd/sd-netlink/netlink-types-rtnl.c b/src/libsystemd/sd-netlink/netlink-types-rtnl.c
+index 167bbc5ccfc6..fd60760e71da 100644
+--- a/src/libsystemd/sd-netlink/netlink-types-rtnl.c
++++ b/src/libsystemd/sd-netlink/netlink-types-rtnl.c
+@@ -483,6 +483,7 @@ static const struct NLType rtnl_bridge_port_types[] = {
+         [IFLA_BRPORT_MRP_IN_OPEN]           = { .type = NETLINK_TYPE_U8 },
+         [IFLA_BRPORT_MCAST_EHT_HOSTS_LIMIT] = { .type = NETLINK_TYPE_U32 },
+         [IFLA_BRPORT_MCAST_EHT_HOSTS_CNT]   = { .type = NETLINK_TYPE_U32 },
++        [IFLA_BRPORT_LOCKED]                = { .type = NETLINK_TYPE_U8 },
+ };
+ 
+ static const NLTypeSystemUnionElement rtnl_link_info_slave_data_type_systems[] = {
+diff --git a/src/network/networkd-network-gperf.gperf b/src/network/networkd-network-gperf.gperf
+index 4c3bf97311d4..3c492e637880 100644
+--- a/src/network/networkd-network-gperf.gperf
++++ b/src/network/networkd-network-gperf.gperf
+@@ -319,6 +319,7 @@ Bridge.ProxyARP,                             config_parse_tristate,
+ Bridge.ProxyARPWiFi,                         config_parse_tristate,                                    0,                             offsetof(Network, bridge_proxy_arp_wifi)
+ Bridge.Priority,                             config_parse_bridge_port_priority,                        0,                             offsetof(Network, priority)
+ Bridge.MulticastRouter,                      config_parse_multicast_router,                            0,                             offsetof(Network, multicast_router)
++Bridge.Locked,                               config_parse_tristate,                                    0,                             offsetof(Network, bridge_locked)
+ BridgeFDB.MACAddress,                        config_parse_fdb_hwaddr,                                  0,                             0
+ BridgeFDB.VLANId,                            config_parse_fdb_vlan_id,                                 0,                             0
+ BridgeFDB.Destination,                       config_parse_fdb_destination,                             0,                             0
+diff --git a/src/network/networkd-network.c b/src/network/networkd-network.c
+index efdedfaa1bfd..a8da727020f0 100644
+--- a/src/network/networkd-network.c
++++ b/src/network/networkd-network.c
+@@ -447,6 +447,7 @@ int network_load_one(Manager *manager, OrderedHashmap **networks, const char *fi
+                 .bridge_proxy_arp_wifi = -1,
+                 .priority = LINK_BRIDGE_PORT_PRIORITY_INVALID,
+                 .multicast_router = _MULTICAST_ROUTER_INVALID,
++                .bridge_locked = -1,
+ 
+                 .lldp_mode = LLDP_MODE_ROUTERS_ONLY,
+                 .lldp_multicast_mode = _SD_LLDP_MULTICAST_MODE_INVALID,
+diff --git a/src/network/networkd-network.h b/src/network/networkd-network.h
+index f7eb37acedaf..9793c6f07dc4 100644
+--- a/src/network/networkd-network.h
++++ b/src/network/networkd-network.h
+@@ -256,6 +256,7 @@ struct Network {
+         uint32_t cost;
+         uint16_t priority;
+         MulticastRouter multicast_router;
++        int bridge_locked;
+ 
+         /* Bridge VLAN */
+         bool use_br_vlan;
+diff --git a/src/network/networkd-setlink.c b/src/network/networkd-setlink.c
+index 1ab58a5bd214..36ae86941fd2 100644
+--- a/src/network/networkd-setlink.c
++++ b/src/network/networkd-setlink.c
+@@ -400,6 +400,12 @@ static int link_configure(
+                                 return log_link_debug_errno(link, r, "Could not append IFLA_BRPORT_MULTICAST_ROUTER attribute: %m");
+                 }
+ 
++                if (link->network->bridge_locked >= 0) {
++                        r = sd_netlink_message_append_u8(req, IFLA_BRPORT_LOCKED, link->network->bridge_locked);
++                        if (r < 0)
++                                return log_link_debug_errno(link, r, "Could not append IFLA_BRPORT_LOCKED attribute: %m");
++                }
++
+                 r = sd_netlink_message_close_container(req);
+                 if (r < 0)
+                         return log_link_debug_errno(link, r, "Could not close IFLA_PROTINFO container: %m");
+-- 
+2.47.1
+

--- a/recipes-core/systemd/files/0003-network-bridge-add-support-for-IFLA_BRPORT_MAB.patch
+++ b/recipes-core/systemd/files/0003-network-bridge-add-support-for-IFLA_BRPORT_MAB.patch
@@ -1,0 +1,94 @@
+From 1f556afcefa668821d5174d4efdb610aa65befd5 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Fri, 24 Jan 2025 16:21:31 +0100
+Subject: [PATCH 3/3] network: bridge: add support for IFLA_BRPORT_MAB
+
+Since linux commit a35ec8e38cdd ("bridge: Add MAC Authentication Bypass
+(MAB) support") it is possible to MAB for bridge ports. In this mode the
+locked port learns again, but the learned fdb entries are locked,
+allowing user space to unlock hosts based on their MAC addresses.
+
+This requires learning to be enabled on the port, and link-local
+learning disabled for the bridge.
+
+Add support to systemd-network for setting the new attribute for bridge
+ports.
+
+Upstream-Status: Backport [https://github.com/systemd/systemd/commit/08a26ecc4733a04fcd763cebd889da1c49672e0e]
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ src/libsystemd/sd-netlink/netlink-types-rtnl.c | 1 +
+ src/network/networkd-network-gperf.gperf       | 1 +
+ src/network/networkd-network.c                 | 1 +
+ src/network/networkd-network.h                 | 1 +
+ src/network/networkd-setlink.c                 | 6 ++++++
+ 5 files changed, 10 insertions(+)
+
+diff --git a/src/libsystemd/sd-netlink/netlink-types-rtnl.c b/src/libsystemd/sd-netlink/netlink-types-rtnl.c
+index fd60760e71da..33cf9e79a781 100644
+--- a/src/libsystemd/sd-netlink/netlink-types-rtnl.c
++++ b/src/libsystemd/sd-netlink/netlink-types-rtnl.c
+@@ -484,6 +484,7 @@ static const struct NLType rtnl_bridge_port_types[] = {
+         [IFLA_BRPORT_MCAST_EHT_HOSTS_LIMIT] = { .type = NETLINK_TYPE_U32 },
+         [IFLA_BRPORT_MCAST_EHT_HOSTS_CNT]   = { .type = NETLINK_TYPE_U32 },
+         [IFLA_BRPORT_LOCKED]                = { .type = NETLINK_TYPE_U8 },
++        [IFLA_BRPORT_MAB]                   = { .type = NETLINK_TYPE_U8 },
+ };
+ 
+ static const NLTypeSystemUnionElement rtnl_link_info_slave_data_type_systems[] = {
+diff --git a/src/network/networkd-network-gperf.gperf b/src/network/networkd-network-gperf.gperf
+index 3c492e637880..75f2829a5127 100644
+--- a/src/network/networkd-network-gperf.gperf
++++ b/src/network/networkd-network-gperf.gperf
+@@ -320,6 +320,7 @@ Bridge.ProxyARPWiFi,                         config_parse_tristate,
+ Bridge.Priority,                             config_parse_bridge_port_priority,                        0,                             offsetof(Network, priority)
+ Bridge.MulticastRouter,                      config_parse_multicast_router,                            0,                             offsetof(Network, multicast_router)
+ Bridge.Locked,                               config_parse_tristate,                                    0,                             offsetof(Network, bridge_locked)
++Bridge.MACAuthenticationBypass,              config_parse_tristate,                                    0,                             offsetof(Network, bridge_mac_authentication_bypass)
+ BridgeFDB.MACAddress,                        config_parse_fdb_hwaddr,                                  0,                             0
+ BridgeFDB.VLANId,                            config_parse_fdb_vlan_id,                                 0,                             0
+ BridgeFDB.Destination,                       config_parse_fdb_destination,                             0,                             0
+diff --git a/src/network/networkd-network.c b/src/network/networkd-network.c
+index a8da727020f0..e1f213b16343 100644
+--- a/src/network/networkd-network.c
++++ b/src/network/networkd-network.c
+@@ -448,6 +448,7 @@ int network_load_one(Manager *manager, OrderedHashmap **networks, const char *fi
+                 .priority = LINK_BRIDGE_PORT_PRIORITY_INVALID,
+                 .multicast_router = _MULTICAST_ROUTER_INVALID,
+                 .bridge_locked = -1,
++                .bridge_mac_authentication_bypass = -1,
+ 
+                 .lldp_mode = LLDP_MODE_ROUTERS_ONLY,
+                 .lldp_multicast_mode = _SD_LLDP_MULTICAST_MODE_INVALID,
+diff --git a/src/network/networkd-network.h b/src/network/networkd-network.h
+index 9793c6f07dc4..67ae31e379dc 100644
+--- a/src/network/networkd-network.h
++++ b/src/network/networkd-network.h
+@@ -257,6 +257,7 @@ struct Network {
+         uint16_t priority;
+         MulticastRouter multicast_router;
+         int bridge_locked;
++        int bridge_mac_authentication_bypass;
+ 
+         /* Bridge VLAN */
+         bool use_br_vlan;
+diff --git a/src/network/networkd-setlink.c b/src/network/networkd-setlink.c
+index 36ae86941fd2..b33ec1a3d53b 100644
+--- a/src/network/networkd-setlink.c
++++ b/src/network/networkd-setlink.c
+@@ -406,6 +406,12 @@ static int link_configure(
+                                 return log_link_debug_errno(link, r, "Could not append IFLA_BRPORT_LOCKED attribute: %m");
+                 }
+ 
++                if (link->network->bridge_mac_authentication_bypass >= 0) {
++                        r = sd_netlink_message_append_u8(req, IFLA_BRPORT_MAB, link->network->bridge_mac_authentication_bypass);
++                        if (r < 0)
++                                return log_link_debug_errno(link, r, "Could not append IFLA_BRPORT_MAB attribute: %m");
++                }
++
+                 r = sd_netlink_message_close_container(req);
+                 if (r < 0)
+                         return log_link_debug_errno(link, r, "Could not close IFLA_PROTINFO container: %m");
+-- 
+2.47.1
+

--- a/recipes-core/systemd/systemd_250%.bbappend
+++ b/recipes-core/systemd/systemd_250%.bbappend
@@ -1,1 +1,9 @@
 require systemd.inc
+
+SRC_URI += " \
+    file://0001-partition-fix-build-with-newer-linux-btrfs.h-uapi-he.patch \
+    file://0001-basic-linux-update-linux-uapi-headers.patch \
+    file://0001-network-bridge-add-support-for-NO_LL_LEARN.patch \
+    file://0002-network-bridge-add-support-for-IFLA_BRPORT_LOCKED.patch \
+    file://0003-network-bridge-add-support-for-IFLA_BRPORT_MAB.patch \
+"


### PR DESCRIPTION
Backport support for locked bridge ports from systemd 258 [1].

[1] https://github.com/systemd/systemd/pull/36150