### PR TITLE
baseboxd: update to 2.3.1

### DIFF
--- a/recipes-extended/baseboxd/baseboxd_2.3.1.bb
+++ b/recipes-extended/baseboxd/baseboxd_2.3.1.bb
@@ -4,7 +4,7 @@ inherit meson
 TARGET_LDFLAGS:remove = "-Wl,--as-needed"
 TARGET_LDFLAGS:append = " -Wl,--no-as-needed"
 
-SRCREV = "ec5fba861b9f50464dc6dcda8d38fd85f69fc5c8"
+SRCREV = "a8c91ae4dfeba53524b101b62394585f7897d898"
 
 # install service and sysconfig
 do_install:append() {


### PR DESCRIPTION
Update baseboxd to 2.3.1:

* a8c91ae4dfeb Bump version to 2.3.1
* 7737d7489ccd Merge pull request #460 from bisdn/jogo_fix_l2_move_learn
* 7170e72d94ff netlink: setup port learning from with the netlink thread
* 00ed2ca2f4a0 controller: fix setting station move configuration