### PR TITLE
hostapd: add two fixes for 802.1x wired driver

### DIFF
--- a/recipes-connectivity/hostapd/files/0001-Split-ap_sta_set_authorized-into-two-steps.patch
+++ b/recipes-connectivity/hostapd/files/0001-Split-ap_sta_set_authorized-into-two-steps.patch
@@ -1,7 +1,7 @@
 From a93fd09c848a181aecaea0c84a0b64e2612075c2 Mon Sep 17 00:00:00 2001
 From: Jouni Malinen <j@w1.fi>
 Date: Sun, 17 Dec 2023 14:09:57 +0200
-Subject: [PATCH 1/7] Split ap_sta_set_authorized() into two steps
+Subject: [PATCH 1/9] Split ap_sta_set_authorized() into two steps
 
 This function is both updating the hostapd-internal sta->flags value and
 sending out the AP-STA-CONNECTED control interface message. When
@@ -191,5 +191,5 @@ index 27e72f9a0164..1ad1137ae16a 100644
  			   struct sta_info *sta, int authorized);
  static inline int ap_sta_is_authorized(struct sta_info *sta)
 -- 
-2.48.1
+2.47.1
 

--- a/recipes-connectivity/hostapd/files/0002-netlink-allow-listening-for-neighbor-events.patch
+++ b/recipes-connectivity/hostapd/files/0002-netlink-allow-listening-for-neighbor-events.patch
@@ -1,7 +1,7 @@
 From 0c14202044d7b10f0a1ed1cffa05068e91c8c75e Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 13 Jan 2025 11:10:41 +0100
-Subject: [PATCH 2/7] netlink: allow listening for neighbor events
+Subject: [PATCH 2/9] netlink: allow listening for neighbor events
 
 Similar how subscribing to link events works, allow subscribing to
 neighbor events, but only subscribe if any callbacks are populated.
@@ -121,5 +121,5 @@ index d3f091c392b0..53813ad85554 100644
  {
  	unsigned short rta_len;
 -- 
-2.48.1
+2.47.1
 

--- a/recipes-connectivity/hostapd/files/0003-add-wired-driver-extra-options.patch
+++ b/recipes-connectivity/hostapd/files/0003-add-wired-driver-extra-options.patch
@@ -1,7 +1,7 @@
 From 55ad721b3e8cc75870f4e0bc1bf0712a0768fc09 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 20 Jan 2025 09:07:56 +0100
-Subject: [PATCH 3/7] add wired driver extra options
+Subject: [PATCH 3/9] add wired driver extra options
 
 Add two options for for driver_wired_linux:
 
@@ -97,5 +97,5 @@ index d3312a34d8f8..0df283baa4a6 100644
  	u8 *own_addr; /* buffer for writing own MAC address */
  };
 -- 
-2.48.1
+2.47.1
 

--- a/recipes-connectivity/hostapd/files/0004-import-base-MAB-handling-code-from-Cumulus.patch
+++ b/recipes-connectivity/hostapd/files/0004-import-base-MAB-handling-code-from-Cumulus.patch
@@ -1,7 +1,7 @@
 From 64c83efde9a4fce302913ab12bcd7e40d2479541 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Wed, 12 Feb 2025 10:49:28 +0100
-Subject: [PATCH 4/7] import base MAB handling code from Cumulus
+Subject: [PATCH 4/9] import base MAB handling code from Cumulus
 
 Import base MAB handling code from Cumulus:
 
@@ -256,5 +256,5 @@ index 6b9dfbca2fbd..4a6339eeeb17 100644
  /* Termination-Action */
  #define RADIUS_TERMINATION_ACTION_DEFAULT 0
 -- 
-2.48.1
+2.47.1
 

--- a/recipes-connectivity/hostapd/files/0005-use-a-timer-for-mab-instead-of-forcing-drivers-to-se.patch
+++ b/recipes-connectivity/hostapd/files/0005-use-a-timer-for-mab-instead-of-forcing-drivers-to-se.patch
@@ -1,7 +1,7 @@
 From 4a1c598884aff4a6c95545f8e4d190032f6fe7dd Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 14 Feb 2025 10:52:51 +0100
-Subject: [PATCH 5/7] use a timer for mab instead of forcing drivers to set it
+Subject: [PATCH 5/9] use a timer for mab instead of forcing drivers to set it
  explicitly
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
@@ -140,5 +140,5 @@ index 446c60f79fe4..0df283baa4a6 100644
  
  	/**
 -- 
-2.48.1
+2.47.1
 

--- a/recipes-connectivity/hostapd/files/0006-drivers-add-a-linux-wired-driver.patch
+++ b/recipes-connectivity/hostapd/files/0006-drivers-add-a-linux-wired-driver.patch
@@ -1,7 +1,7 @@
 From cdfa7d24c731916f7c0c74502fe4db82b53de43e Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 13 Jan 2025 13:04:48 +0100
-Subject: [PATCH 6/7] drivers: add a linux wired driver
+Subject: [PATCH 6/9] drivers: add a linux wired driver
 
 Add a driver making use of the new-ish LOCKED flags for ports and
 neighbors to implement a wired driver for linux.
@@ -848,5 +848,5 @@ index 10eab6a92e17..00bbb97d7306 100644
  
  ifdef CONFIG_DRIVER_WEXT
 -- 
-2.48.1
+2.47.1
 

--- a/recipes-connectivity/hostapd/files/0007-driver_linux_wired-handle-neighs-going-away.patch
+++ b/recipes-connectivity/hostapd/files/0007-driver_linux_wired-handle-neighs-going-away.patch
@@ -1,7 +1,7 @@
 From 9bd79f395ab06894bd21547fc25bdd583fa455dc Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 14 Feb 2025 10:59:57 +0100
-Subject: [PATCH 7/7] driver_linux_wired: handle neighs going away
+Subject: [PATCH 7/9] driver_linux_wired: handle neighs going away
 
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
@@ -80,5 +80,5 @@ index 6d72fcadc41e..8ed3ac7cd5c6 100644
  
  static void wired_driver_hapd_deinit(void *priv);
 -- 
-2.48.1
+2.47.1
 

--- a/recipes-connectivity/hostapd/files/0008-driver_wired_linux-flush-all-entries-on-start-stop.patch
+++ b/recipes-connectivity/hostapd/files/0008-driver_wired_linux-flush-all-entries-on-start-stop.patch
@@ -1,0 +1,37 @@
+From 8178b8de1661ccd24e9aa7d74448ea12e06414e6 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Mon, 17 Feb 2025 14:14:16 +0100
+Subject: [PATCH 8/9] driver_wired_linux: flush all entries on start/stop
+
+Make sure that there are no fdb entries left on start or stop that may
+unlock traffic unexpectedly.
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ src/drivers/driver_wired_linux.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/drivers/driver_wired_linux.c b/src/drivers/driver_wired_linux.c
+index 8ed3ac7cd5c6..0b929c14811c 100644
+--- a/src/drivers/driver_wired_linux.c
++++ b/src/drivers/driver_wired_linux.c
+@@ -713,6 +713,8 @@ static void * wired_driver_hapd_init(struct hostapd_data *hapd,
+ 	if (wired_init_sockets(drv, params->own_addr))
+ 		goto err_out;
+ 
++	driver_wired_linux_flush_port(drv);
++
+ 	ret = driver_wired_linux_set_port_up(drv, true);
+ 	if (ret)
+ 		goto err_out;
+@@ -734,6 +736,7 @@ static void wired_driver_hapd_deinit(void *priv)
+ 
+ 	driver_wired_linux_set_port_up(drv, false);
+ 	driver_wired_linux_set_port_locked(drv, false);
++	driver_wired_linux_flush_port(drv);
+ 
+ 	if (drv->common.sock >= 0) {
+ 		eloop_unregister_read_sock(drv->common.sock);
+-- 
+2.47.1
+

--- a/recipes-connectivity/hostapd/files/0009-driver_wired_linux-wait-for-bridge-attachment.patch
+++ b/recipes-connectivity/hostapd/files/0009-driver_wired_linux-wait-for-bridge-attachment.patch
@@ -1,0 +1,67 @@
+From 0055917ec04ffd2ebe982f826b713a273c7c0a81 Mon Sep 17 00:00:00 2001
+From: Jonas Gorski <jonas.gorski@bisdn.de>
+Date: Mon, 17 Feb 2025 14:36:36 +0100
+Subject: [PATCH 9/9] driver_wired_linux: wait for bridge attachment
+
+If bridge assignment happens in parallel to hostapd bring up, the
+interface may not yet be attached to the bridge when hostapd tries to
+configure the port.
+
+But we cannot configure locked mode while not attached to a bridge, so
+wait until the port has a master (i.e. attached to a bridge).
+
+Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
+---
+ src/drivers/driver_wired_linux.c | 16 +++++++++++++---
+ 1 file changed, 13 insertions(+), 3 deletions(-)
+
+diff --git a/src/drivers/driver_wired_linux.c b/src/drivers/driver_wired_linux.c
+index 0b929c14811c..fbcfd6373e8f 100644
+--- a/src/drivers/driver_wired_linux.c
++++ b/src/drivers/driver_wired_linux.c
+@@ -14,6 +14,7 @@
+ #include "eloop.h"
+ #include "driver.h"
+ #include "driver_wired_common.h"
++#include "linux_ioctl.h"
+ #include "netlink.h"
+ 
+ #include "ap/sta_info.h"
+@@ -658,6 +659,7 @@ static void * wired_driver_hapd_init(struct hostapd_data *hapd,
+ 	struct driver_wired_linux_data *drv;
+ 	struct netlink_config *cfg;
+ 	int ret;
++	char bridge_ifname[IFNAMSIZ];
+ 
+ 	drv = os_zalloc(sizeof(struct driver_wired_linux_data));
+ 	if (drv == NULL) {
+@@ -704,15 +706,23 @@ static void * wired_driver_hapd_init(struct hostapd_data *hapd,
+ 		goto err_out;
+ 	}
+ 
++	if (wired_init_sockets(drv, params->own_addr))
++		goto err_out;
++
++
++	if (linux_master_get(bridge_ifname, params->ifname) < 0) {
++		wpa_printf(MSG_INFO, "driver_linux_wired: waiting for bridge\n");
++		do {
++			sleep(1);
++		} while (linux_master_get(bridge_ifname, params->ifname) < 0);
++	}
++
+ 	ret = driver_wired_linux_set_port_locked(drv, true);
+ 	if (ret) {
+ 		wpa_printf(MSG_INFO, "driver_linux_wired: failed to set port locked: %i\n", ret);
+ 		goto err_out;
+ 	}
+ 
+-	if (wired_init_sockets(drv, params->own_addr))
+-		goto err_out;
+-
+ 	driver_wired_linux_flush_port(drv);
+ 
+ 	ret = driver_wired_linux_set_port_up(drv, true);
+-- 
+2.47.1
+

--- a/recipes-connectivity/hostapd/hostapd_2.10.bbappend
+++ b/recipes-connectivity/hostapd/hostapd_2.10.bbappend
@@ -8,6 +8,8 @@ SRC_URI:append = "\
     file://0005-use-a-timer-for-mab-instead-of-forcing-drivers-to-se.patch \
     file://0006-drivers-add-a-linux-wired-driver.patch \
     file://0007-driver_linux_wired-handle-neighs-going-away.patch \
+    file://0008-driver_wired_linux-flush-all-entries-on-start-stop.patch \
+    file://0009-driver_wired_linux-wait-for-bridge-attachment.patch \
     file://defconfig \
     file://hostapd-wired.conf \
     file://hostapd-wired@.service \


### PR DESCRIPTION
Fix two issues found in internal testing for the wired driver:

1. flush fdb entries on startup and stop

This ensures that no unlocked fdb entries remain after stop, or any previous unlocked entries may unexpectedly allow traffic on startup.

2. wait for bridge attachement on statup

Setting ports to locked only works when attached to a bridge, but on boot startup of hostapd runs in parallel with systemd-networkd, so the port may not be attached to the bridge yet. So wait for the bridge in case the port isn't attached yet.

Fixes: 2ced4ac52570 ("hostapd: add PoC handler for locked ports")