### PR TITLE
distro: bump version to 5.3

### DIFF
--- a/conf/distro/bisdn-linux.conf
+++ b/conf/distro/bisdn-linux.conf
@@ -2,7 +2,7 @@ require conf/distro/poky.conf
 
 DISTRO = "bisdn-linux"
 DISTRO_NAME = "BISDN Linux"
-DISTRO_VERSION = "5.2.1"
+DISTRO_VERSION = "5.3"
 
 DISTRO_CODENAME = "Ortolana"
 DISTROOVERRIDES = "poky:bisdn-linux"


### PR DESCRIPTION
Now with the 802.1x code merged, we are clearly in the new feature release territory, so bump the minor version.