### PR TITLE
v4.: baseboxd: update to 1.13.0

### DIFF
--- a/recipes-extended/baseboxd/baseboxd_1.13.0.bb
+++ b/recipes-extended/baseboxd/baseboxd_1.13.0.bb
@@ -4,7 +4,7 @@ inherit meson
 TARGET_LDFLAGS:remove = "-Wl,--as-needed"
 TARGET_LDFLAGS:append = " -Wl,--no-as-needed"
 
-SRCREV = "927c0257d9119f2acf74665dbf40aa280b47ad49"
+SRCREV = "95b7c6c65a3e1c630278d093853779a963130729"
 
 # install service and sysconfig
 do_install:append() {


### PR DESCRIPTION
Update baseboxd to 1.13.0:

```
95b7c6c65a3e Bump version to 1.13.0
04eb09a8bdd8 Merge pull request #461 from bisdn/jogo_1.x_port_locked
170617c7532c netlink: setup port learning from with the netlink thread
e86a05ef205a controller: fix setting station move configuration
db31e63bdf88 cnetlink: ignore locked fdb entries as well
1dee72dcfc0d cnetlink: properly handle ll neigh handable changes
f13771037958 nl_bridge: handle port locked
81ba2cf045c6 nbi_impl: initialize learning on connect
c667727cf6f4 ofdpa_client: expose per port learning configuration
c2986f1f7eee proto: update with OF-DPA port learn functions
e1b3a00b8091 Merge pull request #464 from bisdn/jogo_1.x_makefilefixes
7a849105b389 Makefile: automatically sign version bumps
0f0a8c32f74a Makefile: make sure a VERSON bump commit only includes VERSION
58f8be44b7c5 Makefile: add support for patchversion bumps
b4cc2c802e38 Makefile: always include the patchver in the version
e4cb7c36020e Makefile: reset minor version to 0 on major version bump
d2d1a1590768 Bump version to 1.12.12
76969e04197b Merge pull request #463 from bisdn/jogo_1.x_port_state_fixes
e8167563b4f5 nbi_impl: set speed/duplex before setting link up
```