### PR TITLE
net-snmp: replace borked patch to fix compilation

### DIFF
--- a/recipes-protocols/net-snmp/net-snmp/0001-unload_all_mibs-fix-memory-leak-by-freeing-tclist.patch
+++ b/recipes-protocols/net-snmp/net-snmp/0001-unload_all_mibs-fix-memory-leak-by-freeing-tclist.patch
@@ -1,0 +1,40 @@
+From 4bd0d9a8a2860c2c46307aef5ee1ccc69f7e3b62 Mon Sep 17 00:00:00 2001
+From: JanSoundhouse <jan.sondhauss@wago.com>
+Date: Mon, 5 Sep 2022 11:25:58 +0200
+Subject: [PATCH] unload_all_mibs: fix memory leak by freeing tclist
+
+tclist is always allocated in netsnmp_init_mib_internals, when doing multiple init_snmp("")/snmp_shutdown("") this memory is never free'd.
+
+Upstream-Status: Backport [https://github.com/net-snmp/net-snmp/commit/4bd0d9a8a2860c2c46307aef5ee1ccc69f7e3b62]
+
+Signed-off-by: Jinfeng Wang <jinfeng.wang.cn@windriver.com>
+---
+ snmplib/parse.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/snmplib/parse.c b/snmplib/parse.c
+index b3e2f3ae5c..71bdf75ff8 100644
+--- a/snmplib/parse.c
++++ b/snmplib/parse.c
+@@ -28,7 +28,7 @@ ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+ SOFTWARE.
+ ******************************************************************/
+ /*
+- * Copyright © 2003 Sun Microsystems, Inc. All rights reserved.
++ * Copyright Â© 2003 Sun Microsystems, Inc. All rights reserved.
+  * Use is subject to license terms specified in the COPYING file
+  * distributed with the Net-SNMP package.
+  */
+@@ -4215,7 +4215,8 @@ unload_all_mibs(void)
+         if (ptc->description)
+             free(ptc->description);
+     }
+-    memset(tclist, 0, tc_alloc * sizeof(struct tc));
++    SNMP_FREE(tclist);
++    tc_alloc = 0;
+ 
+     memset(buckets, 0, sizeof(buckets));
+     memset(nbuckets, 0, sizeof(nbuckets));
+-- 
+2.34.1
+

--- a/recipes-protocols/net-snmp/net-snmp_5.9.3.bbappend
+++ b/recipes-protocols/net-snmp/net-snmp_5.9.3.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"


### PR DESCRIPTION
net-snmp got a broken patch that does not apply, causing the build to break:

    ERROR: net-snmp-5.9.3-r0 do_patch: Applying patch '0001-unload_all_mibs-fix-memory-leak-by-freeing-tclist.patch' on target directory '.../work/cortexa9-vfp-poky-linux-gnueabi/net-snmp/5.9.3-r0/net-snmp-5.9.3'
    CmdError('quilt --quiltrc .../work/cortexa9-vfp-poky-linux-gnueabi/net-snmp/5.9.3-r0/recipe-sysroot-native/etc/quiltrc push', 0, 'stdout: Applying patch 0001-unload_all_mibs-fix-memory-leak-by-freeing-tclist.patch
    patching file snmplib/parse.c
    Hunk #1 FAILED at 28.
    Hunk #2 succeeded at 4225 (offset 10 lines).
    1 out of 2 hunks FAILED -- rejects in file snmplib/parse.c
    Patch 0001-unload_all_mibs-fix-memory-leak-by-freeing-tclist.patch does not apply (enforce with -f)

    stderr: ')

Fix this by providing our own version of the patch that works, fixing the build again.