### PR TITLE
hostapd: fix potential crash with MAB and disconnected clients

### DIFF
--- a/recipes-connectivity/hostapd/files/0001-Split-ap_sta_set_authorized-into-two-steps.patch
+++ b/recipes-connectivity/hostapd/files/0001-Split-ap_sta_set_authorized-into-two-steps.patch
@@ -191,5 +191,5 @@ index 27e72f9a0164..1ad1137ae16a 100644
  			   struct sta_info *sta, int authorized);
  static inline int ap_sta_is_authorized(struct sta_info *sta)
 -- 
-2.47.1
+2.48.1
 

--- a/recipes-connectivity/hostapd/files/0002-netlink-allow-listening-for-neighbor-events.patch
+++ b/recipes-connectivity/hostapd/files/0002-netlink-allow-listening-for-neighbor-events.patch
@@ -121,5 +121,5 @@ index d3f091c392b0..53813ad85554 100644
  {
  	unsigned short rta_len;
 -- 
-2.47.1
+2.48.1
 

--- a/recipes-connectivity/hostapd/files/0003-add-wired-driver-extra-options.patch
+++ b/recipes-connectivity/hostapd/files/0003-add-wired-driver-extra-options.patch
@@ -97,5 +97,5 @@ index d3312a34d8f8..0df283baa4a6 100644
  	u8 *own_addr; /* buffer for writing own MAC address */
  };
 -- 
-2.47.1
+2.48.1
 

--- a/recipes-connectivity/hostapd/files/0004-import-base-MAB-handling-code-from-Cumulus.patch
+++ b/recipes-connectivity/hostapd/files/0004-import-base-MAB-handling-code-from-Cumulus.patch
@@ -256,5 +256,5 @@ index 6b9dfbca2fbd..4a6339eeeb17 100644
  /* Termination-Action */
  #define RADIUS_TERMINATION_ACTION_DEFAULT 0
 -- 
-2.47.1
+2.48.1
 

--- a/recipes-connectivity/hostapd/files/0005-use-a-timer-for-mab-instead-of-forcing-drivers-to-se.patch
+++ b/recipes-connectivity/hostapd/files/0005-use-a-timer-for-mab-instead-of-forcing-drivers-to-se.patch
@@ -1,4 +1,4 @@
-From 4a1c598884aff4a6c95545f8e4d190032f6fe7dd Mon Sep 17 00:00:00 2001
+From e4e892771d631104476455ef95c41bfe72ffd20b Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 14 Feb 2025 10:52:51 +0100
 Subject: [PATCH 5/9] use a timer for mab instead of forcing drivers to set it
@@ -7,9 +7,9 @@ Subject: [PATCH 5/9] use a timer for mab instead of forcing drivers to set it
 Signed-off-by: Jonas Gorski <jonas.gorski@bisdn.de>
 ---
  src/ap/drv_callbacks.c | 11 ++-------
- src/ap/ieee802_1x.c    | 55 ++++++++++++++++++++++++++----------------
+ src/ap/ieee802_1x.c    | 56 ++++++++++++++++++++++++++----------------
  src/drivers/driver.h   |  1 -
- 3 files changed, 36 insertions(+), 31 deletions(-)
+ 3 files changed, 37 insertions(+), 31 deletions(-)
 
 diff --git a/src/ap/drv_callbacks.c b/src/ap/drv_callbacks.c
 index f634ab8890bf..33992331cdcd 100644
@@ -48,7 +48,7 @@ index f634ab8890bf..33992331cdcd 100644
  	case EVENT_EAPOL_RX:
  		hostapd_event_eapol_rx(hapd, data->eapol_rx.src,
 diff --git a/src/ap/ieee802_1x.c b/src/ap/ieee802_1x.c
-index 6748f0d82dd0..ef3628496ae0 100644
+index 6748f0d82dd0..c2b3dce437e3 100644
 --- a/src/ap/ieee802_1x.c
 +++ b/src/ap/ieee802_1x.c
 @@ -1033,6 +1033,32 @@ static void ieee802_1x_save_eapol(struct sta_info *sta, const u8 *buf,
@@ -127,6 +127,14 @@ index 6748f0d82dd0..ef3628496ae0 100644
  		return;
  	}
  
+@@ -1423,6 +1436,7 @@ void ieee802_1x_free_station(struct hostapd_data *hapd, struct sta_info *sta)
+ #ifdef CONFIG_HS20
+ 	eloop_cancel_timeout(ieee802_1x_wnm_notif_send, hapd, sta);
+ #endif /* CONFIG_HS20 */
++	eloop_cancel_timeout(ieee802_1x_handle_eap_rx_timeout, hapd, sta);
+ 
+ 	if (sta->pending_eapol_rx) {
+ 		wpabuf_free(sta->pending_eapol_rx->buf);
 diff --git a/src/drivers/driver.h b/src/drivers/driver.h
 index 446c60f79fe4..0df283baa4a6 100644
 --- a/src/drivers/driver.h
@@ -140,5 +148,5 @@ index 446c60f79fe4..0df283baa4a6 100644
  
  	/**
 -- 
-2.47.1
+2.48.1
 

--- a/recipes-connectivity/hostapd/files/0006-drivers-add-a-linux-wired-driver.patch
+++ b/recipes-connectivity/hostapd/files/0006-drivers-add-a-linux-wired-driver.patch
@@ -1,4 +1,4 @@
-From cdfa7d24c731916f7c0c74502fe4db82b53de43e Mon Sep 17 00:00:00 2001
+From 48f06fe5d5774037d623ea353e49e9e3357b8618 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 13 Jan 2025 13:04:48 +0100
 Subject: [PATCH 6/9] drivers: add a linux wired driver
@@ -848,5 +848,5 @@ index 10eab6a92e17..00bbb97d7306 100644
  
  ifdef CONFIG_DRIVER_WEXT
 -- 
-2.47.1
+2.48.1
 

--- a/recipes-connectivity/hostapd/files/0007-driver_linux_wired-handle-neighs-going-away.patch
+++ b/recipes-connectivity/hostapd/files/0007-driver_linux_wired-handle-neighs-going-away.patch
@@ -1,4 +1,4 @@
-From 9bd79f395ab06894bd21547fc25bdd583fa455dc Mon Sep 17 00:00:00 2001
+From a5ef112d767f7e79c396b5d21982c63d4f919a28 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Fri, 14 Feb 2025 10:59:57 +0100
 Subject: [PATCH 7/9] driver_linux_wired: handle neighs going away
@@ -80,5 +80,5 @@ index 6d72fcadc41e..8ed3ac7cd5c6 100644
  
  static void wired_driver_hapd_deinit(void *priv);
 -- 
-2.47.1
+2.48.1
 

--- a/recipes-connectivity/hostapd/files/0008-driver_wired_linux-flush-all-entries-on-start-stop.patch
+++ b/recipes-connectivity/hostapd/files/0008-driver_wired_linux-flush-all-entries-on-start-stop.patch
@@ -1,4 +1,4 @@
-From 8178b8de1661ccd24e9aa7d74448ea12e06414e6 Mon Sep 17 00:00:00 2001
+From 88fa44e53f3412c5c105f650ff9365f90ce49b50 Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 17 Feb 2025 14:14:16 +0100
 Subject: [PATCH 8/9] driver_wired_linux: flush all entries on start/stop
@@ -33,5 +33,5 @@ index 8ed3ac7cd5c6..0b929c14811c 100644
  	if (drv->common.sock >= 0) {
  		eloop_unregister_read_sock(drv->common.sock);
 -- 
-2.47.1
+2.48.1
 

--- a/recipes-connectivity/hostapd/files/0009-driver_wired_linux-wait-for-bridge-attachment.patch
+++ b/recipes-connectivity/hostapd/files/0009-driver_wired_linux-wait-for-bridge-attachment.patch
@@ -1,4 +1,4 @@
-From 0055917ec04ffd2ebe982f826b713a273c7c0a81 Mon Sep 17 00:00:00 2001
+From 0750ee63edf16e431d82c205ada10bc468e3d19b Mon Sep 17 00:00:00 2001
 From: Jonas Gorski <jonas.gorski@bisdn.de>
 Date: Mon, 17 Feb 2025 14:36:36 +0100
 Subject: [PATCH 9/9] driver_wired_linux: wait for bridge attachment
@@ -63,5 +63,5 @@ index 0b929c14811c..fbcfd6373e8f 100644
  
  	ret = driver_wired_linux_set_port_up(drv, true);
 -- 
-2.47.1
+2.48.1
 


### PR DESCRIPTION
When a client gets immediately disconnected again, hostapd stops any 802.1x and frees its state machine object, but the timeout for switching to MAB may still be active. If the timeout then triggers, it tries to free sta->eapol_sm->identity, which causes a NULL pointer access, since eapol_sm is NULL.

Fix this by also canceling any pending MAB fallback timeouts on stopping 802.1.x

Fixes: 475aaa7a8547 ("hostapd: improve 802.1x support")

(cherry picked from commit 1b368cf90e5fc06ece5f31647fb5759b0afde256)