### PR TITLE
add support for stacked vlans on bridge ports

### DIFF
--- a/recipes-extended/baseboxd/baseboxd_2.4.0.bb
+++ b/recipes-extended/baseboxd/baseboxd_2.4.0.bb
@@ -4,7 +4,7 @@ inherit meson
 TARGET_LDFLAGS:remove = "-Wl,--as-needed"
 TARGET_LDFLAGS:append = " -Wl,--no-as-needed"
 
-SRCREV = "a8c91ae4dfeba53524b101b62394585f7897d898"
+SRCREV = "93139f29d74c2c18b65a526bfe8196c3ff16e76f"
 
 # install service and sysconfig
 do_install:append() {

--- a/recipes-support/rofl-ofdpa/rofl-ofdpa_2.1.0.bb
+++ b/recipes-support/rofl-ofdpa/rofl-ofdpa_2.1.0.bb
@@ -2,4 +2,4 @@
 # Released under the MIT license (see COPYING.MIT for the terms)
 
 require rofl-ofdpa.inc
-SRCREV = "0d3591410f5ada591fc8bd2df78b5b84dc0b0458"
+SRCREV = "0ec499c973bbe619529281b8aa4ad78bfe1a2181"


### PR DESCRIPTION
Update baseboxd to 2.4.0 and rofl-ofdpa to 2.1.0 with the newly added support for encapsulating traffic on a bridge port with a stacked VLAN tag.

This supports adding a VLAN interface as a bridge member, encapsulating all traffic with a VLAN tag based on that VLAN interface.

