### PR TITLE
Backport switch_tcpdump changes

### DIFF
--- a/recipes-extended/man-pages/files/switch_tcpdump.8
+++ b/recipes-extended/man-pages/files/switch_tcpdump.8
@@ -1,0 +1,116 @@
+.\" switch_tcpdump.8
+.TH "SWITCH_TCPDUMP" "8" "8 May 2024" "" "documentation"
+.SH "NAME"
+switch_tcpdump \- dump switch port traffic
+.SH "SYNOPSIS"
+.B switch_tcpdump
+.B \-\-inPort
+.I INPORT
+.br
+[
+.B \-\-filePath
+.I FILEPATH
+[
+.B \-\-maxSize
+.I \%MAXSIZE_MB
+]
+]
+.br
+[
+.B \-\-timeout
+.I TIMEOUT_SECONDS
+]
+[
+.I TCPDUMP_OPTIONS
+]
+
+.SH "DESCRIPTION"
+\fIswitch_tcpdump\fP is a wrapper around
+.BR tcpdump (8).
+
+Its main features are:
+
+.IP
+Inserting a rule into the ACL table to redirect ingress traffic for
+the given port to the CPU (i.e., the Linux kernel).
+.IP
+Deleting the rule from the ACL table when the capture is stopped.
+.IP
+Preventing file system overflow by stopping the capture when the
+capture file reaches a certain size (default 100 MB).
+.IP
+Stopping the capture after a certain amount of time (default 0, meaning
+no timeout).
+.PP
+
+\fIswitch_tcpdump\fP captures all packets arriving on the given port
+and all packets seen by the kernel going through that port (i.e.,
+any packets that you are sending out from the switch through that
+port). It cannot see any packets that are treated exclusively in the
+switch ASIC; this includes packets that are eventually sent out through
+the capture port without being seen by the kernel (e.g., packets that
+are bridged in hardware).
+
+.SH "OPTIONS"
+.TP
+.BI \-\-inPort " INPORT"
+Listen on specified port (named portX). This is a mandatory option.
+.TP
+.BI \-\-filePath " FILEPATH"
+Write the captured packets to the specified file. If not specified,
+packet descriptions are printed to stdout (mirroring tcpdump behavior).
+The maximum file size is limited by the \fB\%\-\-maxSize\fR option.
+.TP
+.BI \-\-maxSize " MAXSIZE_MB"
+MAXSIZE_MB is the maximum size of the capture file in megabytes. The
+mechanism checks the file size every 0.1 seconds. The default value is
+100. Setting MAXSIZE_MB to 0 disables the size limit.
+.TP
+.BI \-\-timeout " TIMEOUT_SECONDS"
+Stop the capture after TIMEOUT_SECONDS seconds.
+.TP
+.I "TCPDUMP_OPTIONS"
+All remaining arguments are passed on to tcpdump.
+
+.SH "EXAMPLES"
+.LP
+To capture seen packets on port3 and write /tmp/pcap (defaults to 100 MB
+limit):
+.RS
+.nf
+\fBswitch_tcpdump --inPort port3 --filePath /tmp/pcap\fP
+.fi
+.RE
+.LP
+To write a capture file with no size limit:
+.RS
+.nf
+\fBswitch_tcpdump --inPort port3 --filePath /tmp/pcap --maxSize 0\fP
+.fi
+.RE
+.LP
+To show for ten seconds all packets seen on port3:
+.RS
+.nf
+\fBswitch_tcpdump --inPort port3 --timeout 10\fP
+.fi
+.RE
+.LP
+Extra arguments (all arguments after "port3" in this case) are passed on to
+tcpdump:
+.RS
+.nf
+\fBswitch_tcpdump --inPort port3 -nv arp or icmp\fP
+.fi
+.RE
+
+.SH "EXIT STATUS"
+\fIswitch_tcpdump\fP returns 2 for all errrors except for \fItcpdump\fP
+errors whose exit status (usually 1 in case of errors) is passed through.
+
+.SH "BUGS"
+Fails to remove the ACL rule if terminated by SIGKILL.
+
+Using \fItcpdump\fP options such as \fB\-i\fR or \fB\-w\fR that
+conflict with \fI\%switch_tcpdump\fP options (e.g., \fB\-\-inPort\fR,
+\fB\-\-filePath\fR) is unsupported and may result in unexpected behavior.

--- a/recipes-extended/man-pages/man-pages_%.bbappend
+++ b/recipes-extended/man-pages/man-pages_%.bbappend
@@ -5,6 +5,7 @@ SRC_URI += " \
   file://onie-bisdn-uninstall.1 \
   file://onie-bisdn-upgrade.1 \
   file://onie-bisdn-rescue.1 \
+  file://switch_tcpdump.8 \
 "
 
 do_install:append() {

--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -29,6 +29,7 @@
 
 import argparse
 import builtins
+import ctypes
 import functools
 import os
 import signal
@@ -189,11 +190,7 @@ def rule_insert(portNumber):
         text=True,
         capture_output=True)
 
-    rc = int.from_bytes(
-        completed_process.returncode.to_bytes(1, "little", signed=False),
-        "little",
-        signed=True,
-    )
+    rc = ctypes.c_int8(completed_process.returncode)
 
     if rc not in [0, -25]:
         print(completed_process.stdout)
@@ -217,11 +214,7 @@ def rule_delete(portNumber):
         text=True,
         capture_output=True)
 
-    rc = int.from_bytes(
-        completed_process.returncode.to_bytes(1, "little", signed=False),
-        "little",
-        signed=True,
-    )
+    rc = ctypes.c_int8(completed_process.returncode)
 
     if rc not in [0, -30]:
         print(completed_process.stdout)

--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -260,6 +260,7 @@ def run_tcpdump(portName, filePath, timeoutSeconds,
                     time.time() - starting_time > timeoutSeconds):
                 tcpdumpProcess.terminate()
                 print("Reached capture timeout, stopping")
+                break
 
             if (maxSizeMB
                     and filePath
@@ -267,6 +268,7 @@ def run_tcpdump(portName, filePath, timeoutSeconds,
                     and int(os.path.getsize(filePath) / 1e6) > maxSizeMB):
                 tcpdumpProcess.terminate()
                 print("Max file size reached, stopping")
+                break
 
     except KeyboardInterrupt:
         tcpdumpProcess.terminate()

--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -38,15 +38,18 @@ import time
 EPILOG = """
 Example usage:
 
-Capture ingress packets on port3 and write at most 100 MB to /tmp/capture.pcap:
-switch_tcpdump --inPort port3 --filePath /tmp/capture.pcap --maxSize 100
+Capture seen packets on port3 and write /tmp/pcap (defaults to 100 MB limit):
+switch_tcpdump --inPort port3 --filePath /tmp/pcap
 
-For ten seconds, show all packets arriving on port3:
+Write a capture file with no size limit:
+switch_tcpdump --inPort port3 --filePath /tmp/pcap --maxSize 0
+
+For ten seconds, show all packets seen on port3:
 switch_tcpdump --inPort port3 --timeout 10
 
-Extra arguments are passed to tcpdump directly. For example, to get
-verbose output for ARP packets arriving on port3, use:
-switch_tcpdump --inPort port3 -v 'arp'
+Extra arguments (all arguments after "port3" in this case) are passed on to
+tcpdump:
+switch_tcpdump --inPort port3 -nv arp or icmp
 """
 
 
@@ -60,7 +63,7 @@ def main():
 
     parser = argparse.ArgumentParser(
         prog="switch_tcpdump",
-        description="Capture ingress packets on switch ports",
+        description="Capture packets on switch ports",
         formatter_class=argparse.RawTextHelpFormatter,
         epilog=EPILOG)
     parser.add_argument(

--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -58,15 +58,16 @@ def main():
         nargs='+',
         help="tcpdump filter arguments")
 
-    group = parser.add_mutually_exclusive_group(required=True)
+    group = parser.add_mutually_exclusive_group()
     group.add_argument(
         "--filePath",
         type=str,
         help="resulting .pcap file location")
+    # This argument is kept for for backward compatibility. It is not used.
     group.add_argument(
         "--stdout",
         action='store_true',
-        help="output to stdout instead of file - overrides file path",
+        help="output to stdout [default]",
         default=False)
 
     args, extra_args = parser.parse_known_args()
@@ -100,7 +101,6 @@ def main():
         args.filePath,
         args.timeout,
         args.maxSize,
-        args.stdout,
         args.filters,
         extra_args)
 
@@ -154,12 +154,12 @@ def rule_delete(portNumber):
 
 
 def run_tcpdump(portName, filePath, timeoutSeconds,
-                maxSizeMB, stdout, filters, extra_args):
+                maxSizeMB, filters, extra_args):
 
     tcpdumpCommand = ["tcpdump", "-i", portName]
 
     # Override file argument for stdout
-    if not stdout:
+    if filePath:
         tcpdumpCommand = tcpdumpCommand + ["-w", filePath]
         print(f"Saving to {filePath}")
 
@@ -187,7 +187,7 @@ def run_tcpdump(portName, filePath, timeoutSeconds,
                 tcpdumpProcess.terminate()
                 print("Reached capture timeout, stopping")
 
-            if not stdout and os.path.isfile(filePath) \
+            if filePath and os.path.isfile(filePath) \
                     and int(os.path.getsize(filePath) / 1e6) > maxSizeMB:
                 tcpdumpProcess.terminate()
                 print("Max file size reached, stopping")
@@ -198,7 +198,7 @@ def run_tcpdump(portName, filePath, timeoutSeconds,
     # Wait for tcpdump to finish writing before starting to print again.
     tcpdumpProcess.wait()
 
-    if not stdout:
+    if filePath:
         print(f"Final file size: {os.path.getsize(filePath)/1e6} MB")
     return tcpdumpProcess.returncode
 

--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -72,10 +72,6 @@ def main():
 
     args, extra_args = parser.parse_known_args()
 
-    print("=" * 80)
-    print("Running switch_tcpdump")
-    print(f"Interface name: {args.inPort}")
-
     if interface_exists(args.inPort) != 0:
         print("Interface %s does not exist" % args.inPort)
         return 1
@@ -94,7 +90,7 @@ def main():
         print("Failed while inserting rule into the ACL table")
         return 1
 
-    print("Rule inserted to the ACL table")
+    print("Set ACL table rule to redirect", args.inPort, "ingress traffic to us")
 
     tcpdumpReturnCode = run_tcpdump(
         args.inPort,
@@ -112,9 +108,6 @@ def main():
 
     print("Rule deleted from the ACL table")
 
-    print("Finished capturing")
-    print("=" * 80)
-
     return tcpdumpReturnCode
 
 
@@ -123,7 +116,8 @@ def interface_exists(interfaceName):
         "/sbin/ip",
         "link",
         "show",
-        interfaceName])
+        interfaceName],
+        stdout=subprocess.DEVNULL)
 
     return completed_process.returncode
 
@@ -161,7 +155,6 @@ def run_tcpdump(portName, filePath, timeoutSeconds,
     # Override file argument for stdout
     if filePath:
         tcpdumpCommand = tcpdumpCommand + ["-w", filePath]
-        print(f"Saving to {filePath}")
 
     if extra_args:
         tcpdumpCommand = tcpdumpCommand + extra_args
@@ -169,13 +162,11 @@ def run_tcpdump(portName, filePath, timeoutSeconds,
     if filters:
         tcpdumpCommand = tcpdumpCommand + filters
 
-    print("Starting tcpdump...")
     if timeoutSeconds:
         print(f"The timeout is {timeoutSeconds} seconds")
-    else:
-        print("Capturing traffic until user interruption")
     starting_time = time.time()
 
+    print("Running", " ".join(tcpdumpCommand))
     tcpdumpProcess = subprocess.Popen(tcpdumpCommand)
 
     try:

--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -194,7 +194,7 @@ def rule_insert(portNumber):
         text=True,
         capture_output=True)
 
-    rc = ctypes.c_int8(completed_process.returncode)
+    rc = ctypes.c_int8(completed_process.returncode).value
 
     if rc not in [0, -25]:
         print(completed_process.stdout)
@@ -218,7 +218,7 @@ def rule_delete(portNumber):
         text=True,
         capture_output=True)
 
-    rc = ctypes.c_int8(completed_process.returncode)
+    rc = ctypes.c_int8(completed_process.returncode).value
 
     if rc not in [0, -30]:
         print(completed_process.stdout)
@@ -275,7 +275,7 @@ def run_tcpdump(portName, filePath, timeoutSeconds,
 
     if filePath:
         print(f"Final file size: {os.path.getsize(filePath)/1e6} MB")
-    return ctypes.c_int8(tcpdumpProcess.returncode)
+    return ctypes.c_int8(tcpdumpProcess.returncode).value
 
 
 if __name__ == "__main__":

--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -144,6 +144,10 @@ def main():
         args.filters,
         extra_args)
 
+    if tcpdumpReturnCode == -15:
+      # SIGTERM was received, which is not an error.
+      tcpdumpReturnCode = 0
+
     # Remove the rule from the ACL table in case it was not removed by the
     # signal handler. Not having the rule anymore (-30) is not an error.
     if rule_delete(portNumber) not in [0, -30]:
@@ -271,7 +275,7 @@ def run_tcpdump(portName, filePath, timeoutSeconds,
 
     if filePath:
         print(f"Final file size: {os.path.getsize(filePath)/1e6} MB")
-    return tcpdumpProcess.returncode
+    return ctypes.c_int8(tcpdumpProcess.returncode)
 
 
 if __name__ == "__main__":

--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -28,6 +28,8 @@
 """
 
 import argparse
+import builtins
+import functools
 import os
 import signal
 import subprocess
@@ -53,6 +55,9 @@ ERROR_EXIT_CODE = 2
 
 
 def main():
+    # Flush print output immediately
+    builtins.print = functools.partial(print, flush=True)
+
     parser = argparse.ArgumentParser(
         prog="switch_tcpdump",
         description="Capture ingress packets on switch ports",

--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -113,6 +113,8 @@ def main():
 
     portNumber = int(args.inPort.replace("port", ""))
 
+    sig_handler = create_signal_handler(portNumber)
+
     rc = rule_insert(portNumber)
     if rc == -25:
         # A conflicting rule is already present in the ACL table. Remove and
@@ -125,6 +127,9 @@ def main():
 
     print("Set ACL table rule to redirect", args.inPort, "ingress traffic to us")
 
+    signal.signal(signal.SIGINT, sig_handler)
+    signal.signal(signal.SIGTERM, sig_handler)
+
     tcpdumpReturnCode = run_tcpdump(
         args.inPort,
         args.filePath,
@@ -133,16 +138,27 @@ def main():
         args.filters,
         extra_args)
 
-    sig = signal.signal(signal.SIGINT, signal.SIG_IGN)
     # Remove the rule from the ACL table in case it was not removed by the
     # signal handler. Not having the rule anymore (-30) is not an error.
     if rule_delete(portNumber) not in [0, -30]:
         return ERROR_EXIT_CODE
-    signal.signal(signal.SIGINT, sig)
-
-    print("Rule deleted from the ACL table")
 
     return tcpdumpReturnCode
+
+def create_signal_handler(portNumber):
+    """
+    Create a signal handler that deletes the ACL table rule and raises
+    KeyboardInterrupt to terminate tcpdump.
+    """
+
+    def sig_handler(signum, frame):
+        if rule_delete(portNumber) != 0:
+            # This should never happen.
+            print("Failed while deleting rule in the ACL table")
+        # Raise KeyboardInterrupt to terminate tcpdump.
+        raise KeyboardInterrupt
+
+    return sig_handler
 
 
 def interface_exists(interfaceName):
@@ -182,6 +198,10 @@ def rule_insert(portNumber):
 
 
 def rule_delete(portNumber):
+    # Prevent interruption of rule_delete and re-entrance of the signal handler
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+
     completed_process = subprocess.run([
         "/usr/sbin/ofdpa_acl_flow_cli.py",
         "-d",

--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -71,7 +71,7 @@ def main():
     parser.add_argument(
         "--maxSize",
         type=int,
-        help="maximum tcpdump file size in MB",
+        help="maximum tcpdump file size in MB (0 for unlimited)",
         default=100)
     parser.add_argument(
         "--timeout",
@@ -205,8 +205,10 @@ def run_tcpdump(portName, filePath, timeoutSeconds,
                 tcpdumpProcess.terminate()
                 print("Reached capture timeout, stopping")
 
-            if filePath and os.path.isfile(filePath) \
-                    and int(os.path.getsize(filePath) / 1e6) > maxSizeMB:
+            if (maxSizeMB
+                    and filePath
+                    and os.path.isfile(filePath)
+                    and int(os.path.getsize(filePath) / 1e6) > maxSizeMB):
                 tcpdumpProcess.terminate()
                 print("Max file size reached, stopping")
 

--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -29,6 +29,7 @@
 
 import argparse
 import os
+import signal
 import subprocess
 import time
 
@@ -102,9 +103,11 @@ def main():
         args.stdout,
         args.filters)
 
+    sig = signal.signal(signal.SIGINT, signal.SIG_IGN)
     if rule_delete(portNumber) != 0:
         print("Failed while deleting rule in the ACL table")
         return 1
+    signal.signal(signal.SIGINT, sig)
 
     print("Rule deleted from the ACL table")
 

--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -157,9 +157,21 @@ def rule_insert(portNumber):
         str(portNumber),
         "--inPortMask",
         "0xffffffff",
-        "--controller"])
+        "--controller"],
+        text=True,
+        capture_output=True)
 
-    return completed_process.returncode
+    rc = int.from_bytes(
+        completed_process.returncode.to_bytes(1, "little", signed=False),
+        "little",
+        signed=True,
+    )
+
+    if rc not in [0, -25]:
+        print(completed_process.stdout)
+        print("Unexpected return code while inserting rule into the ACL table")
+
+    return rc
 
 
 def rule_delete(portNumber):
@@ -169,9 +181,21 @@ def rule_delete(portNumber):
         "--inPort",
         str(portNumber),
         "--inPortMask",
-        "0xffffffff"])
+        "0xffffffff"],
+        text=True,
+        capture_output=True)
 
-    return completed_process.returncode
+    rc = int.from_bytes(
+        completed_process.returncode.to_bytes(1, "little", signed=False),
+        "little",
+        signed=True,
+    )
+
+    if rc not in [0, -30]:
+        print(completed_process.stdout)
+        print("Unexpected return code while deleting rule from the ACL table")
+
+    return rc
 
 
 def run_tcpdump(portName, filePath, timeoutSeconds,

--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -69,7 +69,7 @@ def main():
         help="output to stdout instead of file - overrides file path",
         default=False)
 
-    args = parser.parse_args()
+    args, extra_args = parser.parse_known_args()
 
     print("=" * 80)
     print("Running switch_tcpdump")
@@ -101,7 +101,8 @@ def main():
         args.timeout,
         args.maxSize,
         args.stdout,
-        args.filters)
+        args.filters,
+        extra_args)
 
     sig = signal.signal(signal.SIGINT, signal.SIG_IGN)
     if rule_delete(portNumber) != 0:
@@ -153,7 +154,7 @@ def rule_delete(portNumber):
 
 
 def run_tcpdump(portName, filePath, timeoutSeconds,
-                maxSizeMB, stdout, filters):
+                maxSizeMB, stdout, filters, extra_args):
 
     tcpdumpCommand = ["tcpdump", "-i", portName]
 
@@ -161,6 +162,9 @@ def run_tcpdump(portName, filePath, timeoutSeconds,
     if not stdout:
         tcpdumpCommand = tcpdumpCommand + ["-w", filePath]
         print(f"Saving to {filePath}")
+
+    if extra_args:
+        tcpdumpCommand = tcpdumpCommand + extra_args
 
     if filters:
         tcpdumpCommand = tcpdumpCommand + filters

--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -191,6 +191,9 @@ def run_tcpdump(portName, filePath, timeoutSeconds,
     except KeyboardInterrupt:
         tcpdumpProcess.terminate()
 
+    # Wait for tcpdump to finish writing before starting to print again.
+    tcpdumpProcess.wait()
+
     if not stdout:
         print(f"Final file size: {os.path.getsize(filePath)/1e6} MB")
     return tcpdumpProcess.returncode

--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -48,6 +48,10 @@ switch_tcpdump --inPort port3 -v 'arp'
 """
 
 
+# tcpdump returns 1 on error. Use 2 for this wrapper to indicate the source.
+ERROR_EXIT_CODE = 2
+
+
 def main():
     parser = argparse.ArgumentParser(
         prog="switch_tcpdump",
@@ -92,21 +96,21 @@ def main():
 
     if interface_exists(args.inPort) != 0:
         print("Interface %s does not exist" % args.inPort)
-        return 1
+        return ERROR_EXIT_CODE
 
     if args.maxSize <= 0:
         print("--maxSize should be greater than 0 (got %d)" % args.maxSize)
-        return 1
+        return ERROR_EXIT_CODE
 
     if args.timeout < 0:
         print("--timeout should 0 or greater (got %d)" % args.timeout)
-        return 1
+        return ERROR_EXIT_CODE
 
     portNumber = int(args.inPort.replace("port", ""))
 
     if rule_insert(portNumber) != 0:
         print("Failed while inserting rule into the ACL table")
-        return 1
+        return ERROR_EXIT_CODE
 
     print("Set ACL table rule to redirect", args.inPort, "ingress traffic to us")
 
@@ -121,7 +125,7 @@ def main():
     sig = signal.signal(signal.SIGINT, signal.SIG_IGN)
     if rule_delete(portNumber) != 0:
         print("Failed while deleting rule in the ACL table")
-        return 1
+        return ERROR_EXIT_CODE
     signal.signal(signal.SIGINT, sig)
 
     print("Rule deleted from the ACL table")

--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -113,9 +113,15 @@ def main():
 
     portNumber = int(args.inPort.replace("port", ""))
 
-    if rule_insert(portNumber) != 0:
-        print("Failed while inserting rule into the ACL table")
-        return ERROR_EXIT_CODE
+    rc = rule_insert(portNumber)
+    if rc == -25:
+        # A conflicting rule is already present in the ACL table. Remove and
+        # try again.
+        if rule_delete(portNumber) != 0:
+            return ERROR_EXIT_CODE
+        if rule_insert(portNumber) != 0:
+            print("Failed while inserting rule into the ACL table")
+            return ERROR_EXIT_CODE
 
     print("Set ACL table rule to redirect", args.inPort, "ingress traffic to us")
 
@@ -128,8 +134,9 @@ def main():
         extra_args)
 
     sig = signal.signal(signal.SIGINT, signal.SIG_IGN)
-    if rule_delete(portNumber) != 0:
-        print("Failed while deleting rule in the ACL table")
+    # Remove the rule from the ACL table in case it was not removed by the
+    # signal handler. Not having the rule anymore (-30) is not an error.
+    if rule_delete(portNumber) not in [0, -30]:
         return ERROR_EXIT_CODE
     signal.signal(signal.SIGINT, sig)
 

--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -50,6 +50,8 @@ switch_tcpdump --inPort port3 --timeout 10
 Extra arguments (all arguments after "port3" in this case) are passed on to
 tcpdump:
 switch_tcpdump --inPort port3 -nv arp or icmp
+
+For additional information, see the man page for switch_tcpdump(8).
 """
 
 

--- a/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
+++ b/recipes-extended/ofdpa-tools/ofdpa-tools/switch_tcpdump
@@ -33,11 +33,27 @@ import signal
 import subprocess
 import time
 
+EPILOG = """
+Example usage:
+
+Capture ingress packets on port3 and write at most 100 MB to /tmp/capture.pcap:
+switch_tcpdump --inPort port3 --filePath /tmp/capture.pcap --maxSize 100
+
+For ten seconds, show all packets arriving on port3:
+switch_tcpdump --inPort port3 --timeout 10
+
+Extra arguments are passed to tcpdump directly. For example, to get
+verbose output for ARP packets arriving on port3, use:
+switch_tcpdump --inPort port3 -v 'arp'
+"""
+
 
 def main():
     parser = argparse.ArgumentParser(
         prog="switch_tcpdump",
-        description="Capture packets in the switch controller")
+        description="Capture ingress packets on switch ports",
+        formatter_class=argparse.RawTextHelpFormatter,
+        epilog=EPILOG)
     parser.add_argument(
         "--inPort",
         required=True,
@@ -53,10 +69,12 @@ def main():
         type=int,
         help="capture duration, in seconds (0 for manual stop)",
         default=0)
+    # This argument is kept for for backward compatibility. Filter arguments
+    # can just be appended to the command line without adding "--filters".
     parser.add_argument(
         "--filters",
         nargs='+',
-        help="tcpdump filter arguments")
+        help="tcpdump pcap-filter arguments")
 
     group = parser.add_mutually_exclusive_group()
     group.add_argument(


### PR DESCRIPTION
This PR contains the following changes (backported from main):

- 5899839 switch_tcpdump: use c_byte value, not object
- 0b32033 switch_tcpdump: handle SIGTERM signal indication
- fe16d49 switch_tcpdump: use ctypes to convert to int8
- 68f8c0a switch_tcpdump: break out of loop after terminating tcpdump
- f224da6 Add man page for switch_tcpdump(8)
- e0290d4 switch_tcpdump: update usage examples and usage description
- b271bf0 switch_tcpdump: add custom signal handler
- 51ac1e6 switch_tcpdump: deal with missing/present acl rules automatically
- 1406bc4 switch_tcpdump: capture output from ofdpa_acl_flow_cli
- 8bc6c5f switch_tcpdump: allow unlimited filesize
- e1d3612 switch_tcpdump: flush print output immediately
- 90a8d0d switch_tcpdump: change error exit code
- 88a6a14 switch_tcpdump: update help message
- 601232e switch_tcpdump: clean up output
- 4615d3b switch_tcpdump: make stdout default
- 9423085 switch_tcpdump: pass on extra args to tcpdump
- 7aee95e switch_tcpdump: wait for tcpdump to complete
- 9772da5 switch_tcpdump: prevent interrupt during rule deletion
