### PR TITLE
v4.x: sync support bundle script with main

### DIFF
--- a/recipes-extended/baseboxd-tools/baseboxd-tools/bundle-debug-info
+++ b/recipes-extended/baseboxd-tools/baseboxd-tools/bundle-debug-info
@@ -350,7 +350,7 @@ fi
 
 title "Creating tarball"
 FILE="/tmp/support-data_$(date "+%Y%m%d-%H%M%S").tgz"
-tar czf "$FILE" -C "$TMPDIR" .
+tar czhf "$FILE" -C "$TMPDIR" .
 
 echo "Tarball created: $FILE"
 echo "Please send the tarball to support@bisdn.freshdesk.com"

--- a/recipes-extended/baseboxd-tools/baseboxd-tools/bundle-debug-info
+++ b/recipes-extended/baseboxd-tools/baseboxd-tools/bundle-debug-info
@@ -115,7 +115,7 @@ function copy_path() {
   if [ -e "$cpath" ]; then
     title "Copying $cpath"
     mkdir -p "$TMPDIR/$(dirname "$cpath")"
-    cp -a "$cpath" "$TMPDIR/$cpath"
+    cp -aL "$cpath" "$TMPDIR/$cpath"
   fi
 }
 

--- a/recipes-extended/baseboxd-tools/baseboxd-tools/bundle-debug-info
+++ b/recipes-extended/baseboxd-tools/baseboxd-tools/bundle-debug-info
@@ -149,6 +149,7 @@ function get_network_state() {
   log_cmd_output sysctl net.ipv4.ip_forward
   log_cmd_output sysctl net.ipv6.conf.all.forwarding
   log_cmd_output ip a
+  log_cmd_output ip -d link show
   log_cmd_output ip route list table all
   log_cmd_output ip neigh
   log_cmd_output ip nexthop

--- a/recipes-extended/baseboxd-tools/baseboxd-tools/bundle-debug-info
+++ b/recipes-extended/baseboxd-tools/baseboxd-tools/bundle-debug-info
@@ -149,6 +149,7 @@ function get_network_state() {
   log_cmd_output ip a
   log_cmd_output ip route list table all
   log_cmd_output ip neigh
+  log_cmd_output ip nexthop
   log_cmd_output bridge fdb
   if grep -q bridge.ko "/lib/modules/$(uname -r)/modules.builtin" ||
       grep "^bridge " /proc/modules; then

--- a/recipes-extended/baseboxd-tools/baseboxd-tools/bundle-debug-info
+++ b/recipes-extended/baseboxd-tools/baseboxd-tools/bundle-debug-info
@@ -15,6 +15,8 @@ if [[ $EUID -ne 0 ]]; then
    exit 1
 fi
 
+SYSTEMCTL=$(command -v systemctl)
+
 ###############################################################################
 # Helper functions
 ###############################################################################
@@ -204,9 +206,9 @@ function get_port_list() {
 function get_mstpd_state() {
   title "Retrieving MSTPD state"
   OUTPUT_FILE="$TMPDIR/mstpd_state"
-  IGNORE_ERRORS=1 LST="Service State" log_cmd_output /bin/systemctl status mstpd
+  IGNORE_ERRORS=1 LST="Service State" log_cmd_output $SYSTEMCTL status mstpd
 
-  if ! /bin/systemctl is-active --quiet mstpd; then
+  if ! $SYSTEMCTL is-active --quiet mstpd; then
     return 0
   fi
 


### PR DESCRIPTION
Backport latest change to bundle-debug-info so we properly collect data for newest features backported to 4.x as well.

Backports of:

* https://github.com/bisdn/meta-bisdn-linux/pull/145
* https://github.com/bisdn/meta-bisdn-linux/pull/146
* https://github.com/bisdn/meta-bisdn-linux/pull/242
* https://github.com/bisdn/meta-bisdn-linux/pull/245
* https://github.com/bisdn/meta-bisdn-linux/pull/290