### PR TITLE
baseboxd: update to 2.4.1

### DIFF
--- a/recipes-extended/baseboxd/baseboxd_2.4.1.bb
+++ b/recipes-extended/baseboxd/baseboxd_2.4.1.bb
@@ -4,7 +4,7 @@ inherit meson
 TARGET_LDFLAGS:remove = "-Wl,--as-needed"
 TARGET_LDFLAGS:append = " -Wl,--no-as-needed"
 
-SRCREV = "93139f29d74c2c18b65a526bfe8196c3ff16e76f"
+SRCREV = "0d22b4455666e36334e3faec664ded394d124726"
 
 # install service and sysconfig
 do_install:append() {


### PR DESCRIPTION
Update baseboxd to 2.4.1:

    0d22b4455666 Bump version to 2.4.1
    100355642229 Merge pull request #469 from bisdn/jogo_sync_route_on_linkdown
    fee7384d987a Merge pull request #470 from bisdn/jogo_route_nh_fallback
    9a58b5ddbe9e cnetlink: sync route cache on linkdown events
    9d601cc759c0 nl_l3: do not reject routes with 0 nnhs
    a4f2faa8aa05 nl_l3::get_neighbours_of_route(): handle route with just a nhid
    58c3666b00f9 cnetlink: add a function for looking up nexthops by id
    64cd0e593d23 cnetlink: allow looking up routes by dst and nhid
    9c0438fe0217 cnetlink: use nh_params directly for route lookup
    5d1371a5286d cnetlink: track kernel nexthops
    30f933f3ca2e controller: allow ECMP routes pointing to CONTROLLER
