### PR TITLE
v4.x: add support for stacked vlans on bridge ports

### DIFF
--- a/recipes-extended/baseboxd/baseboxd_1.14.0.bb
+++ b/recipes-extended/baseboxd/baseboxd_1.14.0.bb
@@ -4,7 +4,7 @@ inherit meson
 TARGET_LDFLAGS:remove = "-Wl,--as-needed"
 TARGET_LDFLAGS:append = " -Wl,--no-as-needed"
 
-SRCREV = "877a5361b0aca9ff8d098db3a14adedf8ecb535a"
+SRCREV = "237977e8dba973e8e61b59f3013740c7181fd490"
 
 # install service and sysconfig
 do_install:append() {

--- a/recipes-support/rofl-ofdpa/rofl-ofdpa_2.1.0.bb
+++ b/recipes-support/rofl-ofdpa/rofl-ofdpa_2.1.0.bb
@@ -2,4 +2,4 @@
 # Released under the MIT license (see COPYING.MIT for the terms)
 
 require rofl-ofdpa.inc
-SRCREV = "0d3591410f5ada591fc8bd2df78b5b84dc0b0458"
+SRCREV = "0ec499c973bbe619529281b8aa4ad78bfe1a2181"


### PR DESCRIPTION
Update baseboxd to 1.14.0 and rofl-ofdpa to 2.1.0 with the newly added support for encapsulating traffic on a bridge port with a stacked VLAN tag.

This supports adding a VLAN interface as a bridge member, encapsulating all traffic with a VLAN tag based on that VLAN interface.
