### PR TITLE
Revert "baseboxd: update to 2.4.1"

### DIFF
--- a/recipes-extended/baseboxd/baseboxd_2.4.0.bb
+++ b/recipes-extended/baseboxd/baseboxd_2.4.0.bb
@@ -4,7 +4,7 @@ inherit meson
 TARGET_LDFLAGS:remove = "-Wl,--as-needed"
 TARGET_LDFLAGS:append = " -Wl,--no-as-needed"
 
-SRCREV = "0d22b4455666e36334e3faec664ded394d124726"
+SRCREV = "93139f29d74c2c18b65a526bfe8196c3ff16e76f"
 
 # install service and sysconfig
 do_install:append() {


### PR DESCRIPTION
It looks like the link sync introduces several regressions, so go back to the previous, much more stable version. E.g. l3 neighbors may get marked as unroutable, and IPv6 routes may go missing after a link change.

This reverts commit 1316cfc198f31c71bbdd2a65125b06f3744483d8.