### PR TITLE
prevent backup of /etc/opkg/arch.conf again

### DIFF
--- a/recipes-core/feed-config/b-isdn-feed-config-opkg_1.0.bb
+++ b/recipes-core/feed-config/b-isdn-feed-config-opkg_1.0.bb
@@ -1,7 +1,7 @@
 SUMMARY = "OPKG package feed configuration"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
-PR = "r3"
+PR = "r4"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 INHIBIT_DEFAULT_DEPS = "1"
 
@@ -11,18 +11,8 @@ INHIBIT_DEFAULT_DEPS = "1"
 do_compile() {
 	mkdir -p ${S}/${sysconfdir}/opkg/
 
-	archconf=${S}/${sysconfdir}/opkg/arch.conf
-
-	rm -f $archconf
-	ipkgarchs="${ALL_MULTILIB_PACKAGE_ARCHS}"
 	# we only create feeds for a subset of supported archs
 	feedarchs="all ${TUNE_PKGARCH} ${MACHINE_ARCH}"
-	priority=1
-	for arch in $ipkgarchs; do 
-		echo "arch $arch $priority" >> $archconf
-		priority=$(expr $priority + 5)
-	done
-
 	basefeedconf=${S}/${sysconfdir}/opkg/base-feeds.conf
 
 	rm -f $basefeedconf

--- a/recipes-devtools/opkg/opkg-arch-config_%.bbappend
+++ b/recipes-devtools/opkg/opkg-arch-config_%.bbappend
@@ -1,0 +1,2 @@
+# allow replacing the arch.conf when going back to 4.x
+CONFFILES:${PN}:remove = " ${sysconfdir}/opkg/arch.conf"


### PR DESCRIPTION
When we removed the bisdn-feed-config-opkg CONFFILES section in 0ac329e44b81 ("bisdn-feed-config-opkg: do not mark files as CONFFILES"), we assumed that this is the only source for these files. But it turns out there is also the Yocto base package 'opkg-arch-config' installing this file marked as a configuration file.

This triggers a backup of the file, and thus a broken machine feed when going back to 4.x or earlier release.

Since the only file provided by 'opkg-arch-config' is identical to the one provided by bisdn-feed-config-opkg, let's just not provide one by us, and unmark the one from opkg-arch-config as config.

Fixes: 0ac329e44b81 ("bisdn-feed-config-opkg: do not mark files as CONFFILES")