### PR TITLE
lmsensors: fix build without sensord

### DIFF
--- a/recipes-bsp/lm_sensors/lmsensors_3.6.0.bbappend
+++ b/recipes-bsp/lm_sensors/lmsensors_3.6.0.bbappend
@@ -1,0 +1,3 @@
+# work around breackage from 86b20b84ec27 (lmsensors: Clean stale files
+# for sensord to avoid incorrect GCC header dependencies)
+EXTRA_OEMAKE:append = ' PROG_EXTRA="sensors ${PACKAGECONFIG_CONFARGS}"'


### PR DESCRIPTION
Until kirkstone is patched, apply the fix locally for the recently introduced breakage from [1].

[1] https://patchwork.yoctoproject.org/project/oe/patch/20250424125034.73053-1-l.anderweit@phytec.de/