### PR TITLE
baseboxd: update to 2.4.2

### DIFF
--- a/recipes-extended/baseboxd/baseboxd_2.4.2.bb
+++ b/recipes-extended/baseboxd/baseboxd_2.4.2.bb
@@ -4,7 +4,7 @@ inherit meson
 TARGET_LDFLAGS:remove = "-Wl,--as-needed"
 TARGET_LDFLAGS:append = " -Wl,--no-as-needed"
 
-SRCREV = "93139f29d74c2c18b65a526bfe8196c3ff16e76f"
+SRCREV = "5f66228f217569c5d760333c7194767295355ebc"
 
 # install service and sysconfig
 do_install:append() {


### PR DESCRIPTION
Update baseboxd to 2.4.2:

```
5f66228f2175 Bump version to 2.4.2
db2ba9c33bf7 Merge pull request #474 from bisdn/jogo_revert_sync_routes 
a313eb9b1366 Revert "cnetlink: sync route cache on linkdown events" 
85a0ecc47b5b Merge pull request #473 from bisdn/jogo_linter_settings 
7d9f4d6a512d linter: invert the push branch restrictions 
c6585c7cf1e2 linter: always lint pull requests
9f664e582004 linter.yml: change default branch from master to main
```