### PR TITLE
baseboxd-tools: bundle-debug-info: include port counters

### DIFF
--- a/recipes-extended/baseboxd-tools/baseboxd-tools/bundle-debug-info
+++ b/recipes-extended/baseboxd-tools/baseboxd-tools/bundle-debug-info
@@ -150,6 +150,7 @@ function get_network_state() {
   log_cmd_output sysctl net.ipv6.conf.all.forwarding
   log_cmd_output ip a
   log_cmd_output ip -d link show
+  log_cmd_output ip stats show
   log_cmd_output ip route list table all
   log_cmd_output ip neigh
   log_cmd_output ip nexthop


### PR DESCRIPTION
Now that we have working port counters with knet, let's include them in our debug bundle as well.

Counters will look like this:

```
14: port5: group afstats subgroup mpls
14: port5: group link
    RX:  bytes packets errors dropped  missed   mcast
           952      12      0       0       0       8
    TX:  bytes packets errors dropped carrier collsns
          1062      11      0       0       0       0
14: port5: group offload subgroup l3_stats off used off
14: port5: group offload subgroup hw_stats_info
    l3_stats off used off
14: port5: group offload subgroup cpu_hit
    RX:  bytes packets errors dropped  missed   mcast
           952      12      0       0       0       0
    TX:  bytes packets errors dropped carrier collsns
          1062      11      0       0       0       0
14: port5: group xstats_slave subgroup bond suite 802.3ad
14: port5: group xstats subgroup bond suite 802.3ad
14: port5: group xstats_slave subgroup bridge suite mcast
14: port5: group xstats_slave subgroup bridge suite stp
14: port5: group xstats subgroup bridge suite mcast
14: port5: group xstats subgroup bridge suite stp
```

This will help us identify issues where the switch ASIC unexpectedly drops packets or does not deliver them to the controller.