### PR TITLE
full: add wireguard-tools

### DIFF
--- a/recipes-core/base-files/base-files/system-backup.txt
+++ b/recipes-core/base-files/base-files/system-backup.txt
@@ -17,6 +17,7 @@
 /etc/ssh/ssh_host_rsa_key
 /etc/ssh/ssh_host_rsa_key.pub
 /etc/ofdpa-grpc.conf
+/etc/wireguard
 -/etc/modprobe.d/i2c-i801.conf
 -/etc/modprobe.d/i2c-ismt.conf
 -/etc/opkg/opkg.conf

--- a/recipes-core/images/full.bb
+++ b/recipes-core/images/full.bb
@@ -48,6 +48,7 @@ BISDN_SWITCH_IMAGE_EXTRA_INSTALL += "\
     tcpdump \
     tmux \
     vim \
+    wireguard-tools \
     "
 
 IMAGE_LINGUAS = "en-us"


### PR DESCRIPTION
Add wireguard-tools package to image to allow using wireguard tunnels.
Since wireguard uses a directory for its configuration and configuration
files can only bet set as files, add /etc/wireguard to system-backup.txt
as well.

Depends on https://github.com/bisdn/meta-open-network-linux/pull/188