### PR TITLE
distro: properly set INIT_MANAGER to "systemd"

### DIFF
--- a/conf/distro/bisdn-linux.conf
+++ b/conf/distro/bisdn-linux.conf
@@ -22,8 +22,6 @@ INIT_MANAGER = "systemd"
 VIRTUAL-RUNTIME_initscripts = ""
 
 VIRTUAL-RUNTIME_login_manager = "systemd"
-PREFERRED_PROVIDER_udev ?= "systemd"
-PREFERRED_PROVIDER_udev-utils ?= "systemd"
 
 BAD_RECOMMENDATIONS ?= "busybox-syslog"
 DISTRO_FEATURES:remove = "alsa opengl wayland vulkan"

--- a/conf/distro/bisdn-linux.conf
+++ b/conf/distro/bisdn-linux.conf
@@ -14,10 +14,11 @@ PACKAGE_FEED_URIS ??= "${FEEDDOMAIN}/${FEEDURIPREFIX}"
 PACKAGE_FEED_BASE_PATHS ??= "ipk"
 PACKAGEFEED_ARCHS ??= "all ${TUNE_PKGARCH} ${MACHINE_ARCH}"
 
-DISTRO_FEATURES_DEFAULT ?= "acl argp ext2 ipv4 ipv6 largefile pci manpages systemd usbhost vfat virtualization xattr"
+DISTRO_FEATURES_DEFAULT ?= "acl argp ext2 ipv4 ipv6 largefile pci manpages usbhost vfat virtualization xattr"
 
-VIRTUAL-RUNTIME_init_manager = "systemd"
-DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit pulseaudio"
+DISTRO_FEATURES_BACKFILL_CONSIDERED:append = " pulseaudio"
+
+INIT_MANAGER = "systemd"
 VIRTUAL-RUNTIME_initscripts = ""
 
 VIRTUAL-RUNTIME_login_manager = "systemd"


### PR DESCRIPTION
By default Yocto kirkstone uses `INIT_MANAGER = "none"`, and we set various variables appropriately for systemd by hand.

Instead of that, let's set `INIT_MANAGER` to "systemd", so Yocto will take care of that for us [1]. This simplifies the distro configuration a bit.

While at it, also drop the now unneded `PREFERRED_PROVIDER` for `udev{,-utils}`.

[1] https://github.com/openembedded/openembedded-core/blob/42344347be29f0997cc2f7636d9603b1fe1875ae/meta/conf/distro/include/init-manager-systemd.inc