### PR TITLE
baseboxd-tools: drop obsolete email instructions for debug bundles

### DIFF
--- a/recipes-extended/baseboxd-tools/baseboxd-tools/bundle-debug-info
+++ b/recipes-extended/baseboxd-tools/baseboxd-tools/bundle-debug-info
@@ -358,6 +358,5 @@ FILE="/tmp/support-data_$(date "+%Y%m%d-%H%M%S").tgz"
 tar czhf "$FILE" -C "$TMPDIR" .
 
 echo "Tarball created: $FILE"
-echo "Please send the tarball to support@bisdn.freshdesk.com"
 
 rm -rf "$TMPDIR"


### PR DESCRIPTION
We stopped using freshdesk, and there is no public support email replacement. So drop the instructions to email the result to it.

Usually we will have instructed users to run bundle-debug-info, so we can also tell them where to send the result.