### PR TITLE
baseboxd: use Termination MAC instead of ACL flows for reserved multicast

### DIFF
--- a/recipes-extended/baseboxd/baseboxd_3.0.0.bb
+++ b/recipes-extended/baseboxd/baseboxd_3.0.0.bb
@@ -4,7 +4,7 @@ inherit meson
 TARGET_LDFLAGS:remove = "-Wl,--as-needed"
 TARGET_LDFLAGS:append = " -Wl,--no-as-needed"
 
-SRCREV = "5c915dd0728440afcd0020cc30982bb3ab198655"
+SRCREV = "70f869daadf7d746e5d514e7e3eddcd97336b704"
 
 # install service and sysconfig
 do_install:append() {

--- a/recipes-support/rofl-ofdpa/rofl-ofdpa_2.2.0.bb
+++ b/recipes-support/rofl-ofdpa/rofl-ofdpa_2.2.0.bb
@@ -2,4 +2,4 @@
 # Released under the MIT license (see COPYING.MIT for the terms)
 
 require rofl-ofdpa.inc
-SRCREV = "0ec499c973bbe619529281b8aa4ad78bfe1a2181"
+SRCREV = "fb1be0ad92a2ff5905fd9b9920dc040a42aac573"


### PR DESCRIPTION
Update baseboxd to 3.0.0 and rofl-ofdpa to 2.2.0 to enable the use of Termination MAC flows instead of ACL flows for reserved multicast traffic.

Fixes https://github.com/bisdn/bisdn-linux/issues/155.