### PR TITLE
baseboxd: update to 3.0.1

### DIFF
--- a/recipes-extended/baseboxd/baseboxd_3.0.1.bb
+++ b/recipes-extended/baseboxd/baseboxd_3.0.1.bb
@@ -4,7 +4,7 @@ inherit meson
 TARGET_LDFLAGS:remove = "-Wl,--as-needed"
 TARGET_LDFLAGS:append = " -Wl,--no-as-needed"
 
-SRCREV = "70f869daadf7d746e5d514e7e3eddcd97336b704"
+SRCREV = "2fba7fa39a16874541e6fc0c2eebf3cad78a6fbf"
 
 # install service and sysconfig
 do_install:append() {


### PR DESCRIPTION
Update baseboxd to 3.0.1:

2fba7fa39a16 Bump version to 3.0.1
5692f72d16f4 fix nl_addr leaks detected by valgrind (#480)
77e0098481db nl_l3: fix IPv6 multicast prefix
44be4bfb3914 nl_l3: statically allocate comparison addresses
0e08577d2bcf nl_bridge: statically allocate comparison addresses